### PR TITLE
Sync grid example code and other docs fixes

### DIFF
--- a/demos/demos.md
+++ b/demos/demos.md
@@ -16,4 +16,3 @@ backTo: / Missing.css
 {.list-of-links .flow-gap}
 
 </main>
-

--- a/dev-notes
+++ b/dev-notes
@@ -51,8 +51,8 @@ class="1 3s 5l" 1 col on desktop or tablet, 3 cols on phone, 5 cols on big
 Updating docs is hard and I always forget something. Consider putting docs next
 to code:
 
-- using npm:literate-postcss
-- using some tool that extracts comments from css
+ - using npm:literate-postcss
+ - using some tool that extracts comments from css
 
 -- dz4k
 

--- a/docs/20-forms.md
+++ b/docs/20-forms.md
@@ -76,7 +76,8 @@ The accepted way to label a group of radio buttons is to use `<fieldset>` and
 This works in missing.css, but these two elements are [notorious] for being
 hard to style. You can use the following pattern instead:
 
-  <figure><figcaption>Note the role, aria-labelledby and the ID on the label itself.</figcaption>
+<figure>
+<figcaption>Note the role, aria-labelledby and the ID on the label itself.</figcaption>
 
   ~~~ html
   <div role=radiogroup aria-labelledby=color-lbl>
@@ -88,8 +89,8 @@ hard to style. You can use the following pattern instead:
     </div>
   </div>
   ~~~
-  
-  </figure>
+
+</figure>
 
 The above will work with [tabular forms](#tabular-form):
 

--- a/docs/40-aria.md
+++ b/docs/40-aria.md
@@ -57,53 +57,62 @@ Use `menu` and `menuitem` roles — see [WAI: Menu][].
 
 To get the actual behavior of an accessible menu, you can use [Missing.js &sect; Menu](/docs/js#menu).
 
-~~~ html
-<div role="menu" hidden id="my-menu">
-  <a role="menuitem">View</a>
-  <a role="menuitem">Edit</a>
-  <a role="menuitem">Delete</a>
-</div>
-~~~
+<figure>
 
-<div>
-<script type="module" src="/missing-js/menu.js"></script>
-<button aria-haspopup="menu" aria-controls="my-menu" aria-expanded="false">Open menu</button>
-<div role="menu" hidden id="my-menu">
-  <a role="menuitem">View</a>
-  <a role="menuitem">Edit</a>
-  <a role="menuitem">Delete</a>
-</div>
-</div>
+  ~~~ html
+  <div role="menu" hidden id="my-menu">
+    <a role="menuitem">View</a>
+    <a role="menuitem">Edit</a>
+    <a role="menuitem">Delete</a>
+  </div>
+  ~~~
+
+  <div>
+  <script type="module" src="/missing-js/menu.js"></script>
+  <button aria-haspopup="menu" aria-controls="my-menu" aria-expanded="false">Open menu</button>
+  <div role="menu" hidden id="my-menu">
+    <a role="menuitem">View</a>
+    <a role="menuitem">Edit</a>
+    <a role="menuitem">Delete</a>
+  </div>
+  </div>
+
+</figure>
 
 [WAI: Menu]: https://www.w3.org/WAI/ARIA/apg/patterns/menu/
+
 
 ## Listbox
 
 Use `listbox` and `option` ARIA roles. [WAI: Listbox][].
 
-~~~ html
-<ul role="listbox" class="box flow-gap">
-  <li role="option" aria-selected="true" class="crowded">
-    <strong>Pick me!</strong>
-    <p>I'm clearly the best option.</p>
-  </li>
-  <li role="option" class="crowded">
-    <strong>Pick me instead!</strong>
-    <p>Don't listen to that other guy.</p>
-  </li>
-</ul>
-~~~
+<figure>
 
-<ul role="listbox" class="box flow-gap">
-  <li role="option" aria-selected="true" class="crowded">
-    <strong>Pick me!</strong>
-    <p>I'm clearly the best option.</p>
-  </li>
-  <li role="option" class="crowded">
-    <strong>Pick me instead!</strong>
-    <p>Don't listen to that other guy.</p>
-  </li>
-</ul>
+  ~~~ html
+  <ul role="listbox" class="box flow-gap">
+    <li role="option" aria-selected="true" class="crowded">
+      <strong>Pick me!</strong>
+      <p>I'm clearly the best option.</p>
+    </li>
+    <li role="option" class="crowded">
+      <strong>Pick me instead!</strong>
+      <p>Don't listen to that other guy.</p>
+    </li>
+  </ul>
+  ~~~
+
+  <ul role="listbox" class="box flow-gap">
+    <li role="option" aria-selected="true" class="crowded">
+      <strong>Pick me!</strong>
+      <p>I'm clearly the best option.</p>
+    </li>
+    <li role="option" class="crowded">
+      <strong>Pick me instead!</strong>
+      <p>Don't listen to that other guy.</p>
+    </li>
+  </ul>
+
+</figure>
 
 [WAI: Listbox]: https://www.w3.org/WAI/ARIA/apg/patterns/menu/
 
@@ -113,15 +122,38 @@ Use `listbox` and `option` ARIA roles. [WAI: Listbox][].
 Any element with the `toolbar` role will have the same styles as a `.tool-bar`.
 The fiex direction will be set based on `aria-orientation`.
 
-<p class="tool-bar">
-<button type="button">Cut</button>
-<button type="button">Copy</button>
-<button type="button">Paste</button>
-</p>
+<figure>
 
+  ~~~ html
+  <p class="tool-bar">
+    <button type="button">Cut</button>
+    <button type="button">Copy</button>
+    <button type="button">Paste</button>
+  </p>
+  ~~~
 
-<p class="tool-bar" aria-orientation="vertical">
-<button type="button">Cut</button>
-<button type="button">Copy</button>
-<button type="button">Paste</button>
-</p>
+  <p class="tool-bar">
+    <button type="button">Cut</button>
+    <button type="button">Copy</button>
+    <button type="button">Paste</button>
+  </p>
+
+</figure>
+
+<figure>
+
+  ~~~ html
+  <p class="tool-bar" aria-orientation="vertical">
+    <button type="button">Cut</button>
+    <button type="button">Copy</button>
+    <button type="button">Paste</button>
+  </p>
+  ~~~
+
+  <p class="tool-bar" aria-orientation="vertical">
+    <button type="button">Cut</button>
+    <button type="button">Copy</button>
+    <button type="button">Paste</button>
+  </p>
+
+</figure>

--- a/docs/50-colorways.md
+++ b/docs/50-colorways.md
@@ -23,14 +23,14 @@ here is the `.ok` colorway in the missing.css source code:
 
 The following colorways are provided by default:
 
- * <dfn>`.plain`</dfn> is the default. {.plain .bg .color}
- * <dfn>`.info`</dfn> is used to highlight information without any emotional 
+ - <dfn>`.plain`</dfn> is the default. {.plain .bg .color}
+ - <dfn>`.info`</dfn> is used to highlight information without any emotional 
    affect. {.info .bg .color}
- * <dfn>`.ok`</dfn> is used to indicate successes, insertions, desired
+ - <dfn>`.ok`</dfn> is used to indicate successes, insertions, desired
    states. {.ok .bg .color}
- * <dfn>`.warn`</dfn> is used to warn the user, although there may not necessarily be a bad
+ - <dfn>`.warn`</dfn> is used to warn the user, although there may not necessarily be a bad
    situation. {.warn .bg .color}
- * <dfn>`.bad`</dfn> is used for errors, deletions, failure states. {.bad .bg .color}
+ - <dfn>`.bad`</dfn> is used for errors, deletions, failure states. {.bad .bg .color}
 
 Applying the colorway class to an element will not change its appearance by 
 default. Use the <dfn>`.bg`</dfn>, <dfn>`.color`</dfn> and <dfn>`.border`</dfn>
@@ -46,6 +46,7 @@ classes to use an aspect of the colorway:
   ~~~
 
 </figure>
+
 
 ## Custom colorways
 

--- a/docs/60-variables.md
+++ b/docs/60-variables.md
@@ -130,6 +130,7 @@ classes; these will be listed in the documentation for that class.
     
     </div>
 
+
 ## Density
 
 <dfn>`--density`</dfn> {#var-density}

--- a/docs/80-utils.md
+++ b/docs/80-utils.md
@@ -15,6 +15,7 @@ missing.css has a collection of classes and custom elements.
 <dfn>`.vh`</dfn>, <dfn>`<v-h>`</dfn>
 :   Visually hide a content without hiding it from assistive software.
 
+
 ## Container
 
 `<div class="container">`
@@ -105,16 +106,16 @@ You can set `--density` yourself in inline styles or your own CSS:
 
 The following classes can be used to make one element look like another:
 
-- <dfn>`.<h1>`</dfn>
-- <dfn>`.<h2>`</dfn>
-- <dfn>`.<h3>`</dfn>
-- <dfn>`.<h4>`</dfn>
-- <dfn>`.<h5>`</dfn>
-- <dfn>`.<h6>`</dfn>
-- <dfn>`.<button>`</dfn>
-- <dfn>`.<a>`</dfn>
-- <dfn>`.<small>`</dfn>
-{role="list" .tool-bar}
+ - <dfn>`.<h1>`</dfn>
+ - <dfn>`.<h2>`</dfn>
+ - <dfn>`.<h3>`</dfn>
+ - <dfn>`.<h4>`</dfn>
+ - <dfn>`.<h5>`</dfn>
+ - <dfn>`.<h6>`</dfn>
+ - <dfn>`.<button>`</dfn>
+ - <dfn>`.<a>`</dfn>
+ - <dfn>`.<small>`</dfn>
+ {role="list" .tool-bar}
 
 <figure>
 

--- a/docs/A0-grid.md
+++ b/docs/A0-grid.md
@@ -37,18 +37,18 @@ add `@s` (small, &le;768px) or `@l` (large, &ge;1024px) to the end of the attrib
 
 <figure>
 
-~~~ html
-<div class="grid grid-even-rows">
+  ~~~ html
+  <div class="grid grid-even-rows">
     <div class="box info" data-cols="1 2" data-rows="1 2">Sidebar  </div>
     <div class="box info" data-cols="3 5" data-rows="1 3">Main     </div>
     <div class="box info" data-cols="6" data-rows="2" data-cols@s="3 5" data-rows@s="4">Aux</div>
-</div>
-~~~
+  </div>
+  ~~~
 
-<div class="grid grid-even-rows">
+  <div class="grid grid-even-rows">
     <div class="box info" data-cols="1 2" data-rows="1 2">Sidebar  </div>
     <div class="box info" data-cols="3 5" data-rows="1 3">Main     </div>
     <div class="box info" data-cols="6" data-rows="2" data-cols@s="3 5" data-rows@s="4">Aux</div>
-</div>
+  </div>
 
 </figure>

--- a/docs/A0-grid.md
+++ b/docs/A0-grid.md
@@ -40,8 +40,8 @@ add `@s` (small, &le;768px) or `@l` (large, &ge;1024px) to the end of the attrib
 ~~~ html
 <div class="grid grid-even-rows">
     <div class="box info" data-cols="1 2" data-rows="1 2">Sidebar  </div>
-    <div class="box info" data-cols="2 4" data-rows="1 3">Main     </div>
-    <div class="box info" data-cols="5 6" data-rows="2" data-cols@s="2 4" data-rows@s="4">Auxiliary</div>
+    <div class="box info" data-cols="3 5" data-rows="1 3">Main     </div>
+    <div class="box info" data-cols="6" data-rows="2" data-cols@s="3 5" data-rows@s="4">Aux</div>
 </div>
 ~~~
 

--- a/docs/B0-js.md
+++ b/docs/B0-js.md
@@ -19,9 +19,13 @@ Add `tabs.js` **as a module script** to your page
 and mark up your tabs with the appropriate ARIA roles.
 Behavior will be added automatically.
 
-~~~
-<script type="module" src="https://the.missing.style/v<%= version %>/missing-js/tabs.js">
-~~~
+<figure>
+
+  ~~~ html
+  <script type="module" src="https://the.missing.style/v<%= version %>/missing-js/tabs.js">
+  ~~~
+
+</figure>
 
 <div class="info box">
 
@@ -29,13 +33,13 @@ Behavior will be added automatically.
 
 For dynamically inserted content: initialize it as such:
 
-<figure class="plain">
+<figure>
 
-~~~ js
-import tabs from "https://the.missing.style/v<%= version %>/missing-js/tabs.js";
-// ... insert some content ...
-tabs(theContentIJustInserted);
-~~~
+  ~~~ js
+  import tabs from "https://the.missing.style/v<%= version %>/missing-js/tabs.js";
+  // ... insert some content ...
+  tabs(theContentIJustInserted);
+  ~~~
 
 <figcaption>Initializing a missing.js behavior on newly inserted content</figcaption>
 
@@ -48,17 +52,26 @@ you could pass the whole `document` every time if you wanted to.
 
 </div>
 
+
 ## Menu
 
 _See [ARIA &sect; menu](/docs/aria/#menu)_
 
-~~~ html
-<script type="module" src="https://the.missing.style/v<%= version %>/missing-js/menu.js">
-~~~
+<figure>
 
-~~~js
-import { menu, menuButton } from "https://the.missing.style/v<%= version %>/missing-js/menu.js";
-~~~
+  ~~~ html
+  <script type="module" src="https://the.missing.style/v<%= version %>/missing-js/menu.js">
+  ~~~
+
+or
+
+<figure>
+
+  ~~~js
+  import { menu, menuButton } from "https://the.missing.style/v<%= version %>/missing-js/menu.js";
+  ~~~
+
+</figure>
 
 All notes above about initializing dynamic content apply here.
 
@@ -67,9 +80,13 @@ All notes above about initializing dynamic content apply here.
 
 _See [Components &sect; Navbar](/docs/components/#navbar)_
 
-~~~ html
-<script type="module" src="https://the.missing.style/v<%= version %>/missing-js/overflow-nav.js">
-~~~
+<figure>
+
+  ~~~ html
+  <script type="module" src="https://the.missing.style/v<%= version %>/missing-js/overflow-nav.js">
+  ~~~
+
+</figure>
 
 Make sure to add:
 
@@ -78,14 +95,14 @@ Make sure to add:
 
 <figure>
 
-~~~ html
-<header class="navbar" data-overflow-nav>
+  ~~~ html
+  <header class="navbar" data-overflow-nav>
     <button class="iconbutton" data-nav-expander aria-hidden>
-        &#x2630; <!-- trigram for heaven -->
+      &#x2630; <!-- trigram for heaven -->
     </button>
     <!-- rest of navbar... -->
-</header>
-~~~
+  </header>
+  ~~~
 
 </figure>
 

--- a/www/pages/concepts.md
+++ b/www/pages/concepts.md
@@ -159,7 +159,6 @@ We would like to see the following components:
 * fix-to-top (?)
 * fix-to-left (?)
 
-
 ## Utility Classes
 
 ### Concept

--- a/www/pages/rfp.md
+++ b/www/pages/rfp.md
@@ -8,9 +8,9 @@ layout: prose.eta
 
 untitled.css is a CSS library that
 
- * starts with good default styling, akin to classless CSS libraries
- * offers components based on purely semantic HTML, utilizing ARIA where appropriate (e.g. tabs)
- * finally, offers a small & curated set of class-based utilities for tweaking
+* starts with good default styling, akin to classless CSS libraries
+* offers components based on purely semantic HTML, utilizing ARIA where appropriate (e.g. tabs)
+* finally, offers a small & curated set of class-based utilities for tweaking
 
 untitled.css aims to minimize intervention in the HTML by allowing developers to start with a good out of the box experience,
  then build common components using plain, semantic HTML and only when they need to go beyond that, apply a minimized \
@@ -117,7 +117,6 @@ We would like to see the following high-power CSS classes:
 * modal (?)
 * fix-to-top (?)
 * fix-to-left (?)
-
 
 ## Utility Classes
 


### PR DESCRIPTION
- Sync grid example code with actual demo (02bca38)
- Various documentation fixes (e2b40e5)
  - Indent all code blocks consistently
  - Add missing `<figure>` elements around example code
  - Normalize spacing before heading
  - Normalize unordered list syntax
  - Normalize code indentation to 2 spaces
  - And other small fixes
