### PR TITLE
Add "main" property to package.json to avoid /index.js fallback by unpkg.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,24 @@
 {
   "name": "missing.css",
   "author": "Deniz Akşimşek <deniz@denizaksimsek.com> (https://dz4k.com)",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "missing.css is the CSS library we wished already existed.",
   "repository": "github:bigskysoftware/missing",
-  "keywords": ["css", "classless-css"],
+  "keywords": [
+    "css",
+    "classless-css"
+  ],
   "license": "BSD 2-Clause",
   "bugs": "https://github.com/bigskysoftware/missing/issues",
   "homepage": "https://missing.style",
-  
   "files": [
     "dist/"
   ],
-  
   "exports": {
     ".": "./dist/missing.min.css",
     "./*": "./dist/*",
     "./prism": "./dist/missing-prism.min.css"
   },
-
   "scripts": {
     "prepack": "deno task build"
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "BSD 2-Clause",
   "bugs": "https://github.com/bigskysoftware/missing/issues",
   "homepage": "https://missing.style",
+  "main": "dist/missing.min.css",
   "files": [
     "dist/"
   ],


### PR DESCRIPTION
Currently, https://unpkg.com/missing.css@1.1.0 redirected to https://unpkg.com/missing.css@1.1.0/index.js. This is probably because there is no `"main"` nor `"unkpg"` in `package.json`.

> If you omit the file path (i.e. use a “bare” URL), unpkg will serve the file specified by the unpkg field in package.json, or fall back to main.

ref. https://unpkg.com/