### PR TITLE
Fix Tabs and Menu Components That Cannot Access JavaScript Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 
 dist
 www/_site
+www/missing-js
 _bin
 
 # Local Netlify folder

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
     "www": "deno task lume",
     "lume": "cd www && echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "css": "deno run -qA tool/css.ts src/missing.css && deno run -qA tool/css.ts src/missing-prism.css",
-    "js": "rm -rf dist/js && cp -r src/js dist/js"
+    "js": "rm -rf dist/js && cp -r src/js dist/js && cp -r dist/js www/missing-js"
   },
   "nodeModulesDir": false,
   "lock": false

--- a/www/_config.ts
+++ b/www/_config.ts
@@ -28,8 +28,10 @@ const site = lume(
   .copy("netlify.redirects", "_redirects")
   .copy("netlify.headers", "_headers")
   .copy("js")
+  .copy("missing-js")
   .addEventListener("afterRender",
     "cd .. && deno task css && deno task js && cp -r dist src www/_site/")
+  .addEventListener("afterRender", "cp -r ../src _site/")
   .data("layout", "docs.vto", "/docs")
   .data("layout", "prose.vto", "/pages")
   .data("layout", "release.vto", "/releases")

--- a/www/releases/1.1.2.md
+++ b/www/releases/1.1.2.md
@@ -1,0 +1,7 @@
+---
+release 1.1.2
+---
+
+# Changelog
+
+- Build step copies `dist/js` into `www/missing-js` so components in pages like `40-aria.md` can function when deployed to Netlify.

--- a/www/releases/1.1.2.md
+++ b/www/releases/1.1.2.md
@@ -1,7 +1,3 @@
----
-release 1.1.2
----
-
 # Changelog
 
 - Build step copies `dist/js` into `www/missing-js` so components in pages like `40-aria.md` can function when deployed to Netlify.


### PR DESCRIPTION
Build step copies `dist/js` into `www/missing-js` so components in pages like `40-aria.md` can function when deployed to Netlify.

I see other JS was contributed to the `www` folder, so I mirrored that structure. If I should modify it in any way please let me know. 