### PR TITLE
Add .dark-theme class to select light/dark theme

### DIFF
--- a/src/variables.css
+++ b/src/variables.css
@@ -66,6 +66,33 @@
 			) / 2);                      /* Divide by 2: there are two page margins */
 }
 
+/* Enable dark theme independently of os preferences*/
+.dark-theme {
+	--fg: var(--gray-0);
+	--muted-fg: var(--gray-2);
+	--faded-fg: var(--gray-7);
+	--plain-bg: var(--gray-11);
+	--info-bg: var(--blue-12);
+	--ok-bg: var(--green-12);
+	--bad-bg: var(--red-12);
+	--warn-bg: var(--yellow-12);
+	--plain-faded-fg: var(--blue-6);
+	--info-faded-fg: var(--blue-6);
+	--ok-faded-fg: var(--green-6);
+	--bad-faded-fg: var(--red-6);
+	--warn-faded-fg: var(--yellow-6);
+	--bg: var(--gray-12);
+	--box-bg: var(--gray-10);
+	--interactive-bg: var(--gray-8);
+	--plain-fg: (--blue-2);
+	--info-fg: var(--blue-2);
+	--ok-fg: var(--green-2);
+	--bad-fg: var(--red-2);
+	--warn-fg: var(--yellow-2);
+	--accent: var(--blue-2);
+	--muted-accent: var(--blue-5)
+}
+
 @media (prefers-color-scheme: dark) {
     :root:not(.-no-dark-theme) {
     	--fg: var(--gray-0);

--- a/src/variables.css
+++ b/src/variables.css
@@ -67,7 +67,7 @@
 }
 
 /* Enable dark theme independently of os preferences*/
-.dark-theme {
+:root.-dark-theme {
 	--fg: var(--gray-0);
 	--muted-fg: var(--gray-2);
 	--faded-fg: var(--gray-7);

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -139,7 +139,7 @@ the following classes:
 
 ### Dark theme
 
-Add the <dfn>`.dark-theme`</dfn> class to your root element to use the dark theme.
+Add the <dfn>`.-dark-theme`</dfn> class to your root element to use the dark theme.
 
 ### No dark theme
 

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -131,12 +131,19 @@ The following classes can be used to make one element look like another:
 
 </figure>
 
+## Theme selection
 
-## No dark theme
+Missing.css, by default applies a light or dark theme based on `prefers-color-scheme`.
+To customize the theme independently of the `prefers-color-scheme` you can use
+the following classes:
 
-Missing.css applies a dark theme based on `prefers-color-scheme`.
-To opt out of this, add the <dfn>`.-no-dark-theme`</dfn> class to your root element.
+### Dark theme
 
+Add the <dfn>`.dark-theme`</dfn> class to your root element to use the dark theme.
+
+### No dark theme
+
+Add the <dfn>`.-no-dark-theme`</dfn> class to your root element to use the light theme.
 
 ## Reset
 


### PR DESCRIPTION
Closes #52 

Motivation (borrowed from #52):

> It's great that missing.css ships with a dark theme, however the theme can only be switched by the OS system system-wide settings.
It would be nice if we could let the user switch the theme as well independently from the system settings.
Ideally we would simply apply an explicit class="dark-theme" to the html element or something similar.


The current behaviour of theme selection is:
 - follow OS preferences by default
 - if `-no-dark-theme` is set on the root element, always use the `light-theme`
 
This pull request will maintain the current behavior and add another case:
- If `.dark-theme` class is set on the root element, theme is always dark 

That is so that current users of `-no-dark-theme` will continue to have the expected behavior. 
When it comes time to release a major version could be better to change the `.-no-dark-theme` class to `.light-theme` for consistency.

I've also updated the docs.