### PR TITLE
Fix stylesheet link in playground result section

### DIFF
--- a/www/pages/playground.html
+++ b/www/pages/playground.html
@@ -26,7 +26,7 @@ url: /playground/
             append "<head>"
             append "<meta charset=UTF-8>"
             append "<meta name=viewport content=width=device-width>"
-            append "<link rel=stylesheet href=/missing.css>"
+            append "<link rel=stylesheet href=/dist/missing.css>"
             append "</head>"
             append "<body>"
             append #code's value


### PR DESCRIPTION
Cheers!
The playground style sheet link is currently broken, making it not very fun to play 😄 . 
This appears to be or be related to what was reported in #34.