### PR TITLE
Fix typos.

### DIFF
--- a/src/layout.css
+++ b/src/layout.css
@@ -80,13 +80,13 @@
 
 /**/
 
-.padding { padding-inline: var(--gap) }
+.padding { padding: var(--gap) }
 .padding-block { padding-block: var(--gap) }
 .padding-block-start { padding-block-start: var(--gap) }
 .padding-block-end { padding-block-end: var(--gap) }
 .padding-inline { padding-inline: var(--gap) }
 .padding-inline-start { padding-inline-start: var(--gap) }
-.padding-inline-end { padding-inline-start: var(--gap) }
+.padding-inline-end { padding-inline-end: var(--gap) }
 
 .margin { margin: var(--gap) }
 .margin-block  { margin-block:  var(--gap) }

--- a/src/main.css
+++ b/src/main.css
@@ -71,7 +71,7 @@ aside {
 h1, h2, h3, h4, h5, h6,
 .\<h1\>, .\<h2\>, .\<h3\>, .\<h4\>, .\<h5\>, .\<h6\> {
 	margin-block-end: var(--gap);
-	font-family: var(--secondary-font);
+	font-family: var(--display-font);
 	font-size: 1em;
 	margin-block-start: calc(2 * var(--gap));
 	position: relative;
@@ -137,7 +137,7 @@ h6:target {
 }
 
 header {
-	font-family: var(--secondary-font);
+	font-family: var(--display-font);
 	border-block-end: 1px solid var(--graphical-fg);
 }
 

--- a/src/utils.css
+++ b/src/utils.css
@@ -37,7 +37,7 @@
 }
 
 
-.primary-font { font-family: var(--primary-font) }
+.main-font, .primary-font { font-family: var(--main-font) }
 .secondary-font { font-family: var(--secondary-font) }
 .display-font { font-family: var(--display-font) }
 .mono-font, .monospace { font-family: var(--mono-font) }

--- a/src/variables.css
+++ b/src/variables.css
@@ -41,7 +41,8 @@
 
 	/* Fonts */
 	--main-font: 'Source Sans 3', 'Source Sans Pro', -apple-system, system-ui, sans-serif;
-	--secondary-font: var(--main-font); /* Headings etc. */
+	--secondary-font: var(--main-font); /* UI elements and captions */
+  --display-font: var(--secondary-font); /* Headings */
 	--mono-font: 'M Plus Code Latin', monospace, monospace; /* monospace twice stops browsers from
 		shrinking this */
 	

--- a/src/variables.css
+++ b/src/variables.css
@@ -84,7 +84,7 @@
 	--bg: var(--gray-12);
 	--box-bg: var(--gray-10);
 	--interactive-bg: var(--gray-8);
-	--plain-fg: (--blue-2);
+	--plain-fg: var(--blue-2);
 	--info-fg: var(--blue-2);
 	--ok-fg: var(--green-2);
 	--bad-fg: var(--red-2);
@@ -115,7 +115,7 @@
     	--box-bg: var(--gray-10);
     	--interactive-bg: var(--gray-8);
 
-		--plain-fg: (--blue-2);
+		--plain-fg: var(--blue-2);
     	--info-fg: var(--blue-2);
     	--ok-fg: var(--green-2);
     	--bad-fg: var(--red-2);

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -113,9 +113,12 @@ classes; these will be listed in the documentation for that class.
 <dfn>`--main-font`</dfn> {#var-main-font}
 :   The main font family for text.
 
-<dfn>`--secondary-font`</dfn> {#var-display-font}
+<dfn>`--secondary-font`</dfn> {#var-secondary-font}
 :   A secondary text font. It's a good idea to specify a sans-serif font as it
-    will be used for buttons.
+    will be used for buttons and captions.
+
+<dfn>`--display-font`</dfn> {#var-display-font}
+:   A display font used for headings.
 
 <dfn>`--mono-font`</dfn> {#var-mono-font}
 :   Monospace font for code, preformatted text, computer input and output.

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -83,8 +83,8 @@ You can set `--density` yourself in inline styles or your own CSS:
 <dfn>`.allcaps`</dfn>
 :   Sets text in all caps and adds appropriate letter spacing.
 
-<dfn>`.primary-font`</dfn>
-:   Renders the text in the primary font (`--primary-font`).
+<dfn>`.main-font`</dfn>
+:   Renders the text in the main font (`--main-font`).
 
 <dfn>`.secondary-font`</dfn>
 :   Renders the text in the secondary font (`--secondary-font`).

--- a/www/docs/90-flex.md
+++ b/www/docs/90-flex.md
@@ -12,7 +12,7 @@ url: ./flex/
 
 <dfn>`.f-row`</dfn> and <dfn>`.f-col`</dfn> will create non-wrapping Flexbox containers, with `flex-direction` set to `row` and `column` respectively.
 
-<dfn>`.f-switch`</dfn> will create a Flexbox container that will switch from row to column when the width of an individual descendant exceeds the <dfn>`--col-width`</dfn> variable (default `15ch`).
+<dfn>`.f-switch`</dfn> will create a Flexbox container that will switch from row to column when the width of an individual descendant exceeds the <dfn>`--f-switch-threshold`</dfn> variable (default `15ch`).
 
 All of `.f-row`, `.f-col` and `.f-switch` will remove margins from their children, and have a [gap] set to `--gap`.
 


### PR DESCRIPTION
I also discovered that there's a clash between `--main-font` and `--primary-font`, where

1. `src/main.css`
2. `src/variables.css`
3. `www/docs/60-variables.md`
4. `www/_includes/layout.vto`

use `--main-font` (and `--secondary-font`), and

1. `src/utils.css`
2. `www/docs/80-utils.md`

use `--primary-font`. 

This change doesn't seem to be documented in any of the `www/release/*.md` files, like the switch from `--display-font` to `--secondary-font` is (and actually, just checking this I see there's still a holdover where `www/docs/80-utils.md` contains an entry for `--display-font`).

If someone could advise on whether to use `--main-font` or `--primary-font`, I can add those fixes (and the `--display-font` one) to this PR.