### PR TITLE
Fix button.\<a\>.

### DIFF
--- a/src/components.css
+++ b/src/components.css
@@ -183,14 +183,14 @@ details,
 		padding-inline-start: 0;
 	}
 
-	& a {
+	& :is(a, .\<a\>) {
 		font-weight: bold;
 		text-decoration: none;
 		padding-inline: .2em;
-	}
 
-	& a:hover, & a:focus {
-		text-decoration: underline;
+	  &:hover, &:focus {
+  		text-decoration: underline;
+    }
 	}
 
 	& [aria-current=page] {

--- a/src/components.css
+++ b/src/components.css
@@ -183,7 +183,7 @@ details,
 		padding-inline-start: 0;
 	}
 
-	& :where(a, .\<a\>) {
+	& :where(a:not(.\<button\>), .\<a\>) {
 		font-weight: bold;
 		text-decoration: none;
 		padding-inline: .2em;

--- a/src/components.css
+++ b/src/components.css
@@ -183,7 +183,7 @@ details,
 		padding-inline-start: 0;
 	}
 
-	& :is(a:not(.\<button\>), .\<a\>) {
+	& :is(a:not(.\<button\>, .chip), .\<a\>) {
 		font-weight: bold;
 		text-decoration: none;
 		padding-inline: .2em;

--- a/src/components.css
+++ b/src/components.css
@@ -183,7 +183,7 @@ details,
 		padding-inline-start: 0;
 	}
 
-	& :is(a, .\<a\>) {
+	& :where(a, .\<a\>) {
 		font-weight: bold;
 		text-decoration: none;
 		padding-inline: .2em;

--- a/src/components.css
+++ b/src/components.css
@@ -183,7 +183,7 @@ details,
 		padding-inline-start: 0;
 	}
 
-	& :where(a:not(.\<button\>), .\<a\>) {
+	& :is(a:not(.\<button\>), .\<a\>) {
 		font-weight: bold;
 		text-decoration: none;
 		padding-inline: .2em;

--- a/src/core/sanitize.css
+++ b/src/core/sanitize.css
@@ -108,7 +108,7 @@ table {
  * Remove the margin on controls in Safari.
  */
 
-:where(button, input, select):not(.\<a\>) {
+button, input, select {
     margin: 0;
 }
 
@@ -116,7 +116,7 @@ table {
  * Correct the inability to style buttons in iOS and Safari.
  */
 
-:where(button, [type="button"], [type="reset"], [type="submit"]):not(.\<a\>) {
+button, [type="button"], [type="reset"], [type="submit"]) {
     -webkit-appearance: button;
 }
 

--- a/src/core/sanitize.css
+++ b/src/core/sanitize.css
@@ -108,7 +108,7 @@ table {
  * Remove the margin on controls in Safari.
  */
 
-:is(button, input, select):not(.\<a\>) {
+:where(button, input, select):not(.\<a\>) {
     margin: 0;
 }
 
@@ -116,7 +116,7 @@ table {
  * Correct the inability to style buttons in iOS and Safari.
  */
 
-:is(button, [type="button"], [type="reset"], [type="submit"]):not(.\<a\>) {
+:where(button, [type="button"], [type="reset"], [type="submit"]):not(.\<a\>) {
     -webkit-appearance: button;
 }
 

--- a/src/core/sanitize.css
+++ b/src/core/sanitize.css
@@ -108,7 +108,7 @@ table {
  * Remove the margin on controls in Safari.
  */
 
-button, input, select {
+:is(button, input, select):not(.\<a\>) {
     margin: 0;
 }
 
@@ -116,7 +116,7 @@ button, input, select {
  * Correct the inability to style buttons in iOS and Safari.
  */
 
-button, [type="button"], [type="reset"], [type="submit"] {
+:is(button, [type="button"], [type="reset"], [type="submit"]):not(.\<a\>) {
     -webkit-appearance: button;
 }
 

--- a/src/main.css
+++ b/src/main.css
@@ -25,7 +25,7 @@ header, footer, section + section {
 }
 
 nav {
-	& a {
+	& :is(a, .\<a\>) {
 		text-decoration: none;
 		color: var(--accent);
 	}
@@ -291,6 +291,7 @@ a, .\<a\> {
 	background: none;
 	border: none;
 	font-size: 1em;
+  font-family: inherit;
 	text-decoration: 1px dotted underline;
 	
 	.list-of-links & {
@@ -484,11 +485,13 @@ label :is(input, select):not([specificity-hack]) {
 	display: inline; padding-block: 0;
 }
 
-button,
-input[type="submit"],
-input[type="reset"],
-input[type="button"],
-.\<button\>,
+:is(
+  button,
+  input[type="submit"],
+  input[type="reset"],
+  input[type="button"],
+  .\<button\>
+):not(.\<a\>),
 input::file-selector-button {
 	display: inline-block;
 	padding: 0 calc(var(--rhythm) / 4);
@@ -538,11 +541,13 @@ input::file-selector-button {
 }
 
 
-button,
-input[type="submit"],
-input[type="reset"],
-input[type="button"],
-.\<button\> {
+:is(
+  button,
+  input[type="submit"],
+  input[type="reset"],
+  input[type="button"],
+  .\<button\>
+):not(.\<a\>) {
 	&:active:is([aria-pressed], [aria-expanded]) {
 		color: var(--accent);
 		box-shadow: 0 1px 5px -1px var(--fg) inset;

--- a/src/main.css
+++ b/src/main.css
@@ -25,7 +25,7 @@ header, footer, section + section {
 }
 
 nav {
-	& :where(a, .\<a\>) {
+	& :where(a:not(.\<button\>), .\<a\>) {
 		text-decoration: none;
 		color: var(--accent);
 	}
@@ -284,7 +284,7 @@ main {
 
 /* Text-level semantics */
 
-a, .\<a\> {
+a:not(.\<button\>), .\<a\> {
 	color: var(--link-fg, var(--accent));
 	border-radius: var(--border-radius);
 	outline-offset: 1px;
@@ -511,6 +511,7 @@ input::file-selector-button {
 
 	/* a-specific resets */
 	color: var(--fg);
+  cursor: default;
 	text-decoration: none;
 	display: inline-flex;
 	justify-content: center;

--- a/src/main.css
+++ b/src/main.css
@@ -25,7 +25,7 @@ header, footer, section + section {
 }
 
 nav {
-	& :where(a:not(.\<button\>), .\<a\>) {
+	& :is(a:not(.\<button\>), .\<a\>) {
 		text-decoration: none;
 		color: var(--accent);
 	}
@@ -284,7 +284,7 @@ main {
 
 /* Text-level semantics */
 
-a:not(.\<button\>), .\<a\> {
+a, .\<a\> {
 	color: var(--link-fg, var(--accent));
 	border-radius: var(--border-radius);
 	outline-offset: 1px;
@@ -511,11 +511,13 @@ input::file-selector-button {
 
 	/* a-specific resets */
 	color: var(--fg);
-  cursor: default;
 	text-decoration: none;
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
+  &:is(a) {
+    cursor: default;
+  }
 
 	&:hover, &:focus-visible {
 		filter: brightness(1.1);

--- a/src/main.css
+++ b/src/main.css
@@ -25,7 +25,7 @@ header, footer, section + section {
 }
 
 nav {
-	& :is(a, .\<a\>) {
+	& :where(a, .\<a\>) {
 		text-decoration: none;
 		color: var(--accent);
 	}
@@ -485,7 +485,7 @@ label :is(input, select):not([specificity-hack]) {
 	display: inline; padding-block: 0;
 }
 
-:is(
+:where(
   button,
   input[type="submit"],
   input[type="reset"],
@@ -541,7 +541,7 @@ input::file-selector-button {
 }
 
 
-:is(
+:where(
   button,
   input[type="submit"],
   input[type="reset"],


### PR DESCRIPTION
The anchor masquerade didn't quite work on button elements:

1) They still had button click states (box-shadows, etc)
2) Didn't inherit fonts, e.g., in `.navbar`
3) Didn't inherit lack of `text-decoration` when in `nav`

This PR should address that, but please let me know if there's something I might not have considered.