### PR TITLE
Add support for <dialog[popover]/>.

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -725,6 +725,7 @@ dialog[open]::backdrop {
 	from { background: transparent; }
 }
 
-dialog:not([open]) {
+dialog:not([popover], [open]),
+[popover]:not(:popover-over) {
     display: none;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -714,7 +714,7 @@ dialog {
 	border-color: var(--fg);
 }
 
-dialog[open]::backdrop {
+dialog:is([open], [popover])::backdrop {
 	display: block;
 	background: black;
 	opacity: .4;


### PR DESCRIPTION
The Popover API can be used to toggle `<dialog>` elements without JS (which mdn says is [perfectly valid](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API)). 

Since the Popover API doesn't use the `[open]` attribute, the result when using missing.css is that the dialogs appear always open. This PR aims to address that. 