### PR TITLE
Toggle

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -117,62 +117,76 @@
     text-align: center;
 }
 
-label:has([role=switch]:last-child) {
-  display: flex;
-  gap: var(--gap);
-  justify-content: space-between;
-}
 
-label[for]:has(+ [role=switch]),
-label[for] + [role=switch],
-[role=switch]:has(+ label[for]),
-[role=switch] + label[for] {
-  display: inline-block;
-  padding-block: calc(var(--gap) / 4);
-}
-
-[role=switch], [aria-pressed] {
-  --toggle-border-width: 0.15em;
+input[type=checkbox][role=switch] {
   all: unset;
   appearance: none;
-  cursor: pointer;
-  display: grid !important;
-  grid-gap: 0;
-  transition: all 0.25s ease-in-out;
-  vertical-align: bottom;
+
+  display: inline-grid;
+  vertical-align: middle;
+  grid-template-columns: repeat(2, 1rem);
+  aspect-ratio: 2 / 1;
+  margin-block: auto;
 
   &::before, &::after {
     content: '';
     display: inline-block;
-    height: var(--rhythm);
-    border: var(--toggle-border-width) solid var(--graphical-fg);
-  }
-  &::before {
-    width: calc(2 * var(--rhythm));
-    background-color: var(--bg);
-    border-radius: var(--rhythm);
-    grid-row: 1;
-    grid-column: 1 / 3;
-  }
-  &::after {
-    width: var(--rhythm);
-    background-color: var(--interactive-bg);
-    border-radius: 50%;
-    grid-row: 1;
-    grid-column: 1 / 2;
-  }
-  &:is(:checked, [aria-pressed=true]) {
-    &::before { background-color: var(--accent); }
-    &::after  { grid-column: 2 / 3; }
+
+    transition: transform .2s ease-in-out, background-color .2s ease-in-out, background-color .2s ease-in-out;
   }
 
-  &:is(:hover, :focus-visible) {
-    /* Reset button styles */
-    filter: unset;
-    box-shadow: none;
+  &::before {
+    grid-column: 1 / span 2;
+    grid-row: 1;
+    border: 1px solid var(--graphical-fg);
+    background: var(--bg);
+    border-radius: 9999rem;
   }
-  &:active {
-    box-shadow: none;
-    color: inherit;
+
+  &::after {
+    --toggle-nub-margin: 2px;
+    grid-column: 1;
+    grid-row: 1;
+    margin: var(--toggle-nub-margin);
+    border-radius: 99999rem;
+    background: var(--graphical-fg);
   }
+
+  &:checked {
+    &::before {
+      border-color: var(--accent);
+      background: var(--accent);
+    }
+    &::after {
+      transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
+      background: var(--bg);
+    }
+  }
+
+  &:indeterminate {
+    &::after {
+      transform: translateX(calc(50% + var(--toggle-nub-margin)));
+      background: var(--bg);
+      border: 1px solid var(--graphical-fg);
+    }
+  }
+
+  &:is(label > *):not(#specificity-hack) {
+    margin-block-end: auto;
+  }
+  &:not(label > *) {
+    padding-block: calc(var(--gap) / 4 + (var(--rhythm) - 1em) / 2);
+  }
+
+  :is(label:has(> &)) {
+    /* Lightning CSS requires :is() when nested selector doesn't start with & */
+    display: flex;
+    gap: var(--gap);
+    flex-direction: row;
+  }
+  :is(label:has(+ &)) {
+    /* Lightning CSS requires :is() when nested selector doesn't start with & */
+    width: 100%;
+  }
+
 }

--- a/src/aria.css
+++ b/src/aria.css
@@ -116,3 +116,49 @@
     width: fit-content;
     text-align: center;
 }
+
+label:has([role=switch]:last-child) {
+  display: flex;
+  justify-content: space-between;
+}
+label[for] + [role=switch] {
+  padding-block: calc(var(--gap) / 4);
+}
+
+label[for]:has(+ [role=switch]),
+label[for] + [role=switch],
+[role=switch]:has(+ label[for]),
+[role=switch] + label[for] {
+  display: inline-block;
+}
+
+[role=switch], [aria-pressed] {
+  --toggle-border-width: 0.2em;
+  all: unset;
+  appearance: none;
+  cursor: pointer;
+  transition: all 0.25s ease-in-out;
+  vertical-align: bottom;
+
+  &::before, &::after {
+    content: '';
+    display: inline-block;
+    height: var(--rhythm);
+    border: var(--toggle-border-width) solid var(--graphical-fg);
+  }
+  &::before {
+    width: calc(2 * var(--rhythm));
+    background-color: var(--bg);
+    border-radius: var(--rhythm);
+  }
+  &::after {
+    width: var(--rhythm);
+    background-color: var(--interactive-bg);
+    border-radius: 50%;
+    transform: translateX(calc(-2 * var(--rhythm)));
+  }
+  &:is(:checked, [aria-pressed=true]) {
+    &::before { background-color: var(--accent); }
+    &::after  { transform: translateX(calc(-1 * var(--rhythm))); }
+  }
+}

--- a/src/aria.css
+++ b/src/aria.css
@@ -119,10 +119,8 @@
 
 label:has([role=switch]:last-child) {
   display: flex;
+  gap: var(--gap);
   justify-content: space-between;
-}
-label[for] + [role=switch] {
-  padding-block: calc(var(--gap) / 4);
 }
 
 label[for]:has(+ [role=switch]),
@@ -130,13 +128,16 @@ label[for] + [role=switch],
 [role=switch]:has(+ label[for]),
 [role=switch] + label[for] {
   display: inline-block;
+  padding-block: calc(var(--gap) / 4);
 }
 
 [role=switch], [aria-pressed] {
-  --toggle-border-width: 0.2em;
+  --toggle-border-width: 0.15em;
   all: unset;
   appearance: none;
   cursor: pointer;
+  display: grid !important;
+  grid-gap: 0;
   transition: all 0.25s ease-in-out;
   vertical-align: bottom;
 
@@ -150,15 +151,28 @@ label[for] + [role=switch],
     width: calc(2 * var(--rhythm));
     background-color: var(--bg);
     border-radius: var(--rhythm);
+    grid-row: 1;
+    grid-column: 1 / 3;
   }
   &::after {
     width: var(--rhythm);
     background-color: var(--interactive-bg);
     border-radius: 50%;
-    transform: translateX(calc(-2 * var(--rhythm)));
+    grid-row: 1;
+    grid-column: 1 / 2;
   }
   &:is(:checked, [aria-pressed=true]) {
     &::before { background-color: var(--accent); }
-    &::after  { transform: translateX(calc(-1 * var(--rhythm))); }
+    &::after  { grid-column: 2 / 3; }
+  }
+
+  &:is(:hover, :focus-visible) {
+    /* Reset button styles */
+    filter: unset;
+    box-shadow: none;
+  }
+  &:active {
+    box-shadow: none;
+    color: inherit;
   }
 }

--- a/src/core/sanitize.css
+++ b/src/core/sanitize.css
@@ -116,7 +116,7 @@ button, input, select {
  * Correct the inability to style buttons in iOS and Safari.
  */
 
-button, [type="button"], [type="reset"], [type="submit"]) {
+button, [type="button"], [type="reset"], [type="submit"] {
     -webkit-appearance: button;
 }
 

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -1,4 +1,4 @@
-/** 
+/**
  * a DOM helper library.
  * "1 US$ = 18.5842 TR₺ · Oct 16, 2022, 20:52 UTC"
  */
@@ -42,13 +42,13 @@
 /**
  * Creates a logging function.
  * The {@link scope} will be prepended to each message logged.
- * 
+ *
  * We usually use `ilog` as a name for the resulting function.
  * It returns its last argument,
  * which makes it easier to log intermediate values in an expression:
- * 
+ *
  *     const x = a + ilog("b:", b); // x = a + b
- * 
+ *
  * @param {string} scope The name of the component/module/etc. that will use this logger.
  * @returns {Logger} The `ilog` function.
  */
@@ -103,14 +103,14 @@ export function traverse(
       ? $(root, selector)
       : $$(root, selector).at(-1);
   }
-  
+
   if (!current) return wrapIt();
-  
+
   // Traverse left to right, bottom to top.
   //
   //                                                  (begin ascii art diagram)
   //                           (R)
-  //                         /     \   
+  //                         /     \
   //                    (r)           (4) <- return value
   //                 /   |   \       /   \
   //    current -> (1)  (2)  (3)    (*) (*)
@@ -118,11 +118,11 @@ export function traverse(
   //
   // In the diagram above, 1, 2, 3 are tested by the selector (assuming we
   // start at 1). Then, having run out of siblings, we move up (as many times
-  // as needed) before advancing, ending up at 4. 
+  // as needed) before advancing, ending up at 4.
   //
   // To "test" an element, ee call Element#matches, then if that returns false,
   // querySelector. The querySelector call is how the items marked with
-  // asterisks can be checked. 
+  // asterisks can be checked.
   let cursor = current;
   while (true) {
     while (cursor[advance] === null) { // 3
@@ -169,7 +169,7 @@ export function $$(scope, sel) {
  * @property {EventTarget} target
  * @property {string} type
  * @property {EventListener} listener
- * @property {object} options  
+ * @property {object} options
  */
 
 /**
@@ -211,7 +211,7 @@ export function off({ target, type, listener, options }) {
 /**
  * "Halt" an event -- convenient wrapper for `preventDefault`, `stopPropagation`, and `stopImmediatePropagation`.
  * @param {string} o - How to halt. Space-separated list of "default", "bubbling" and "propagation".
- * @param {Event} e - The event. 
+ * @param {Event} e - The event.
  */
 export function halt(o, e) {
   for (const t of o.split(" ")) {
@@ -226,7 +226,7 @@ export function halt(o, e) {
 
 /**
  * Decorator for any event listener to call {@link halt}.
- * 
+ *
  *     on(el, "click", halts("default", e => ...))
  *
  * @template {Event} T
@@ -251,13 +251,13 @@ export function dispatch(el, type, detail, options) {
 
 /**
  * Get, remove or set an attribute.
- * 
+ *
  * - attr(el, "name") Get the attribute "name"
  * - attr(el, "name", "value") Set the attribute "name" to "value"
  * - attr(el, "name", null) Remove the attribute "name"
  * - attr(el, [ nameA: "valueA", nameB: "valueB" ]) Set the attributes name-a to "valueA", name-b to "valueB"
- * 
- * @param {Element} el 
+ *
+ * @param {Element} el
  * @param {string | Record<string, unknown>} name - The attribute name **or** a map of names to values.
  *   If an object is passed, camelCase attribute names will be converted to kebab-case.
  * @param {unknown} value - The value of the attribute, when setting. Pass `null` to remove an attribute.
@@ -333,9 +333,9 @@ export function htmlescape(s) {
  * Template literal that escapes HTML in interpolated values and returns a DocumentFragment.
  * Can also be called with a string to parse it as HTML.
  * To let trusted HTML through escaping, parse it first:
- * 
+ *
  *     html`<p>My trusted markup: ${html(trustedMarkup)}</p>`
- * 
+ *
  * @param {TemplateStringsArray | string} str
  * @param {...unknown} values
  * @returns {DocumentFragment}
@@ -421,10 +421,10 @@ export function prev(root, selector, current, options = {}) {
 
 /**
  * Create a handler for keyboard events using a keyboard shortcut DSL.
- * 
+ *
  * - "ArrowLeft"
  * - "Ctrl+Alt+3"
- * 
+ *
  * @param {Record<string, KeyboardEventListener>} hotkeys
  * @returns KeyboardEventListener
  */
@@ -440,7 +440,7 @@ export function hotkey(hotkeys) {
       const
         tokens = hotkeySpec.split("+"), key = /** @type {string} */ (tokens.pop());
       let modifiers = 0 | 0;
-      for (const token in tokens)
+      for (const token of tokens)
         switch (token.toLowerCase()) {
           case "alt": modifiers |= alt; break;
           case "ctrl": modifiers |= ctrl; break;
@@ -460,8 +460,8 @@ export function hotkey(hotkeys) {
 
 /**
  * Debounce a function.
- * 
- * @template {unknown[]} TArgs 
+ *
+ * @template {unknown[]} TArgs
  * @param {number} t The debounce time.
  * @param {(...args: TArgs) => void} f The function.
  * @param {object} [options]
@@ -507,13 +507,13 @@ export function behavior(selector, init) {
 /**
  * @template TData
  * @typedef {object} Repeater
- * 
+ *
  * @property {(datum: TData) => string} idOf
  * Returns the HTML id for a given data value.
- * 
+ *
  * @property {(datum: TData, ctx: { id: string }) => ChildNode} create
  * Creates a an element for a data value.
- * 
+ *
  * @property {(el: Element, datum: TData) => Element | null} update
  * Update an element for a new data value.
  */

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -221,7 +221,7 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
         <input type="checkbox" role="switch"> Toggle me
       </label>
       <label>
-        <input type="checkbox" role="switch"> But not me
+        <input type="checkbox" role="switch" checked> But not me
       </label>
       <label>
         <input type="checkbox" role="switch"> I'm not sure
@@ -233,7 +233,7 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
         Toggle me <input type="checkbox" role="switch">
       </label>
       <label>
-        But not me <input type="checkbox" role="switch">
+        But not me <input type="checkbox" role="switch" checked>
       </label>
       <label>
         I'm not sure <input type="checkbox" role="switch">
@@ -249,7 +249,7 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
         <input type="checkbox" role="switch"> Toggle me
       </label>
       <label>
-        <input type="checkbox" role="switch"> But not me
+        <input type="checkbox" role="switch" checked> But not me
       </label>
       <label>
         <input type="checkbox" role="switch"> I'm not sure
@@ -261,7 +261,7 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
         Toggle me <input type="checkbox" role="switch">
       </label>
       <label>
-        But not me <input type="checkbox" role="switch">
+        But not me <input type="checkbox" role="switch" checked>
       </label>
       <label>
         I'm not sure <input type="checkbox" role="switch">
@@ -273,30 +273,30 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
   <div class="f-switch">
     <fieldset class="f-col">
       <legend>Toggles before labels</legend>
-      <div>
+      <div class="f-row">
         <input id="toggle-1" type="checkbox" role="switch">
         <label for="toggle-1">Toggle me</label>
       </div>
-      <div>
-        <input id="toggle-2"type="checkbox" role="switch">
+      <div class="f-row">
+        <input id="toggle-2"type="checkbox" role="switch" checked>
         <label for="toggle-2">But not me</label>
       </div>
-      <div>
+      <div class="f-row">
         <input if="toggle-3" type="checkbox" role="switch">
         <label for="toggle-3">I'm not sure</label>
       </div>
     </fieldset>
     <fieldset class="f-col">
       <legend>Toggles after labels</legend>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-4">Toggle me</label>
         <input id="toggle-4" type="checkbox" role="switch">
       </div>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-5">But not me</label>
-        <input id="toggle-5" type="checkbox" role="switch">
+        <input id="toggle-5" type="checkbox" role="switch" checked>
       </div>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-6">I'm not sure</label>
         <input id="toggle-6" type="checkbox" role="switch">
       </div>
@@ -307,30 +307,30 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
   <div class="f-switch">
     <fieldset class="f-col">
       <legend>Toggles before labels</legend>
-      <div>
+      <div class="f-row">
         <input id="toggle-1" type="checkbox" role="switch">
         <label for="toggle-1">Toggle me</label>
       </div>
-      <div>
-        <input id="toggle-2"type="checkbox" role="switch">
+      <div class="f-row">
+        <input id="toggle-2"type="checkbox" role="switch" checked>
         <label for="toggle-2">But not me</label>
       </div>
-      <div>
+      <div class="f-row">
         <input if="toggle-3" type="checkbox" role="switch">
         <label for="toggle-3">I'm not sure</label>
       </div>
     </fieldset>
     <fieldset class="f-col">
       <legend>Toggles after labels</legend>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-4">Toggle me</label>
         <input id="toggle-4" type="checkbox" role="switch">
       </div>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-5">But not me</label>
-        <input id="toggle-5" type="checkbox" role="switch">
+        <input id="toggle-5" type="checkbox" role="switch" checked>
       </div>
-      <div>
+      <div class="f-row justify-content:space-between">
         <label for="toggle-6">I'm not sure</label>
         <input id="toggle-6" type="checkbox" role="switch">
       </div>

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -165,7 +165,7 @@ The fiex direction will be set based on `aria-orientation`.
 
 ## Feed
 
-Use `feed` role with `<article/>` children  — see [WAI: Feed][]. Nested feeds are supported.
+Use `feed` role with `<article>` children  — see [WAI: Feed][]. Nested feeds are supported.
 
 To get the actual behavior of an accessible feed, you can use [Missing.js &sect; Feed](/docs/js#feed).
 
@@ -200,3 +200,191 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
 </figure>
 
 [WAI: Menu]: https://www.w3.org/WAI/ARIA/apg/patterns/feed/
+
+
+## Toggle Switch
+
+Use `switch` role with `<input type="checkbox">` or `aria-pressed` with `<button>`.
+
+If using `<button>`, you must provide the JavaScript to toggle `[aria-pressed]`.
+
+Using `<input>` degrades nicely in the absense of JavaScript and also allows for an "indeterminate" state.
+
+<figure>
+<figcaption>Code: Toggle Switches</figcaption>
+
+  ~~~ html
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Toggles inside labels</legend>
+      <label>
+        <input type="checkbox" role="switch"> Toggle me
+      </label>
+      <label>
+        <input type="checkbox" role="switch"> But not me
+      </label>
+      <label>
+        <input type="checkbox" role="switch"> I'm not sure
+      </label>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Toggles inside labels, flipped</legend>
+      <label>
+        Toggle me <input type="checkbox" role="switch">
+      </label>
+      <label>
+        But not me <input type="checkbox" role="switch">
+      </label>
+      <label>
+        I'm not sure <input type="checkbox" role="switch">
+      </label>
+    </fieldset>
+  </div>
+  ~~~
+
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Toggles inside labels</legend>
+      <label>
+        <input type="checkbox" role="switch"> Toggle me
+      </label>
+      <label>
+        <input type="checkbox" role="switch"> But not me
+      </label>
+      <label>
+        <input type="checkbox" role="switch"> I'm not sure
+      </label>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Toggles inside labels, flipped</legend>
+      <label>
+        Toggle me <input type="checkbox" role="switch">
+      </label>
+      <label>
+        But not me <input type="checkbox" role="switch">
+      </label>
+      <label>
+        I'm not sure <input type="checkbox" role="switch">
+      </label>
+    </fieldset>
+  </div>
+
+  ~~~ html
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Toggles before labels</legend>
+      <div>
+        <input id="toggle-1" type="checkbox" role="switch">
+        <label for="toggle-1">Toggle me</label>
+      </div>
+      <div>
+        <input id="toggle-2"type="checkbox" role="switch">
+        <label for="toggle-2">But not me</label>
+      </div>
+      <div>
+        <input if="toggle-3" type="checkbox" role="switch">
+        <label for="toggle-3">I'm not sure</label>
+      </div>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Toggles after labels</legend>
+      <div>
+        <label for="toggle-4">Toggle me</label>
+        <input id="toggle-4" type="checkbox" role="switch">
+      </div>
+      <div>
+        <label for="toggle-5">But not me</label>
+        <input id="toggle-5" type="checkbox" role="switch">
+      </div>
+      <div>
+        <label for="toggle-6">I'm not sure</label>
+        <input id="toggle-6" type="checkbox" role="switch">
+      </div>
+    </fieldset>
+  </div>
+  ~~~
+
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Toggles before labels</legend>
+      <div>
+        <input id="toggle-1" type="checkbox" role="switch">
+        <label for="toggle-1">Toggle me</label>
+      </div>
+      <div>
+        <input id="toggle-2"type="checkbox" role="switch">
+        <label for="toggle-2">But not me</label>
+      </div>
+      <div>
+        <input if="toggle-3" type="checkbox" role="switch">
+        <label for="toggle-3">I'm not sure</label>
+      </div>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Toggles after labels</legend>
+      <div>
+        <label for="toggle-4">Toggle me</label>
+        <input id="toggle-4" type="checkbox" role="switch">
+      </div>
+      <div>
+        <label for="toggle-5">But not me</label>
+        <input id="toggle-5" type="checkbox" role="switch">
+      </div>
+      <div>
+        <label for="toggle-6">I'm not sure</label>
+        <input id="toggle-6" type="checkbox" role="switch">
+      </div>
+    </fieldset>
+  </div>
+
+
+  ~~~ html
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Button toggles</legend>
+      <button type="button" aria-pressed="false">
+        Toggle me
+      </button>
+      <button type="button" aria-pressed="true">
+        But not me
+      </button>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Button toggles, flipped</legend>
+      <button type="button" aria-pressed="false" onclick="this.ariaPressed = this.ariaPressed != 'true'">
+        Toggle me
+      </button>
+      <button type="button" aria-pressed="true" onclick="this.ariaPressed = this.ariaPressed != 'true'">
+        But not me
+      </button>
+    </fieldset>
+  </div>
+  ~~~
+
+  <div class="f-switch">
+    <fieldset class="f-col">
+      <legend>Button toggles</legend>
+      <button type="button" aria-pressed="false">
+        Toggle me
+      </button>
+      <button type="button" aria-pressed="true">
+        But not me
+      </button>
+    </fieldset>
+    <fieldset class="f-col">
+      <legend>Button toggles, flipped</legend>
+      <button type="button" aria-pressed="false" onclick="this.ariaPressed = this.ariaPressed != 'true'">
+        Toggle me
+      </button>
+      <button type="button" aria-pressed="true" onclick="this.ariaPressed = this.ariaPressed != 'true'">
+        But not me
+      </button>
+    </fieldset>
+  </div>
+
+  <strong>TODO</strong>
+  <ul>
+  <li>RTL
+  <li>Indeterminate state
+  </ul>
+</figure>

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -203,11 +203,7 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
 
 ## Toggle Switch
 
-Use `switch` role with `<input type="checkbox">` or `aria-pressed` with `<button>`.
-
-If using `<button>`, you must provide the JavaScript to toggle `[aria-pressed]`.
-
-Using `<input>` degrades nicely in the absense of JavaScript and also allows for an "indeterminate" state.
+Use `switch` role with `<input type="checkbox">`. The indeterminate state is supported, but it must be set with JavaScript.
 
 <figure>
 <figcaption>Code: Toggle Switches</figcaption>
@@ -216,174 +212,111 @@ Using `<input>` degrades nicely in the absense of JavaScript and also allows for
   <div class="f-switch">
     <fieldset class="f-col">
       <legend>Toggles inside labels</legend>
-      <label>
-        <input type="checkbox" role="switch"> Toggle me
-      </label>
-      <label>
-        <input type="checkbox" role="switch" checked> But not me
-      </label>
-      <label>
-        <input type="checkbox" role="switch"> I'm not sure
-      </label>
+      <label><input type="checkbox" role="switch">Toggle me</label>
+      <label><input type="checkbox" role="switch" checked>But not me</label>
+      <label><input type="checkbox" role="switch" class="indeterminate">I'm not sure</label>
     </fieldset>
     <fieldset class="f-col">
       <legend>Toggles inside labels, flipped</legend>
-      <label>
-        Toggle me <input type="checkbox" role="switch">
-      </label>
-      <label>
-        But not me <input type="checkbox" role="switch" checked>
-      </label>
-      <label>
-        I'm not sure <input type="checkbox" role="switch">
-      </label>
+      <label class="justify-content:space-between">Toggle me<input type="checkbox" role="switch"></label>
+      <label class="justify-content:space-between">But not me <input type="checkbox" role="switch" checked></label>
+      <label class="justify-content:space-between">I'm not sure <input type="checkbox" role="switch" class="indeterminate"></label>
     </fieldset>
+    <script>
+      document.querySelectorAll('.indeterminate').forEach(
+        el => {el.indeterminate = true;}
+      )
+    </script>
   </div>
   ~~~
 
   <div class="f-switch">
     <fieldset class="f-col">
       <legend>Toggles inside labels</legend>
-      <label>
-        <input type="checkbox" role="switch"> Toggle me
-      </label>
-      <label>
-        <input type="checkbox" role="switch" checked> But not me
-      </label>
-      <label>
-        <input type="checkbox" role="switch"> I'm not sure
-      </label>
+      <label><input type="checkbox" role="switch">Toggle me</label>
+      <label><input type="checkbox" role="switch" checked>But not me</label>
+      <label><input type="checkbox" role="switch" class="indeterminate">I'm not sure</label>
     </fieldset>
     <fieldset class="f-col">
       <legend>Toggles inside labels, flipped</legend>
-      <label>
-        Toggle me <input type="checkbox" role="switch">
-      </label>
-      <label>
-        But not me <input type="checkbox" role="switch" checked>
-      </label>
-      <label>
-        I'm not sure <input type="checkbox" role="switch">
-      </label>
+      <label class="justify-content:space-between">Toggle me<input type="checkbox" role="switch"></label>
+      <label class="justify-content:space-between">But not me <input type="checkbox" role="switch" checked></label>
+      <label class="justify-content:space-between">I'm not sure <input type="checkbox" role="switch" class="indeterminate"></label>
     </fieldset>
   </div>
 
   ~~~ html
   <div class="f-switch">
-    <fieldset class="f-col">
+    <fieldset class="table rows">
       <legend>Toggles before labels</legend>
-      <div class="f-row">
+      <div>
         <input id="toggle-1" type="checkbox" role="switch">
         <label for="toggle-1">Toggle me</label>
       </div>
-      <div class="f-row">
+      <div>
         <input id="toggle-2"type="checkbox" role="switch" checked>
         <label for="toggle-2">But not me</label>
       </div>
-      <div class="f-row">
-        <input if="toggle-3" type="checkbox" role="switch">
+      <div>
+        <input id="toggle-3" type="checkbox" role="switch" class="indeterminate">
         <label for="toggle-3">I'm not sure</label>
       </div>
     </fieldset>
-    <fieldset class="f-col">
+    <fieldset class="table rows">
       <legend>Toggles after labels</legend>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-4">Toggle me</label>
         <input id="toggle-4" type="checkbox" role="switch">
       </div>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-5">But not me</label>
         <input id="toggle-5" type="checkbox" role="switch" checked>
       </div>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-6">I'm not sure</label>
-        <input id="toggle-6" type="checkbox" role="switch">
+        <input id="toggle-6" type="checkbox" role="switch" class="indeterminate">
       </div>
     </fieldset>
+    <script>
+      document.querySelectorAll('.indeterminate').forEach(
+        el => {el.indeterminate = true;}
+      )
+    </script>
   </div>
   ~~~
 
   <div class="f-switch">
-    <fieldset class="f-col">
+    <fieldset class="table rows">
       <legend>Toggles before labels</legend>
-      <div class="f-row">
+      <div>
         <input id="toggle-1" type="checkbox" role="switch">
         <label for="toggle-1">Toggle me</label>
       </div>
-      <div class="f-row">
+      <div>
         <input id="toggle-2"type="checkbox" role="switch" checked>
         <label for="toggle-2">But not me</label>
       </div>
-      <div class="f-row">
-        <input if="toggle-3" type="checkbox" role="switch">
+      <div>
+        <input id="toggle-3" type="checkbox" role="switch" class="indeterminate">
         <label for="toggle-3">I'm not sure</label>
       </div>
     </fieldset>
-    <fieldset class="f-col">
+    <fieldset class="table rows">
       <legend>Toggles after labels</legend>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-4">Toggle me</label>
         <input id="toggle-4" type="checkbox" role="switch">
       </div>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-5">But not me</label>
         <input id="toggle-5" type="checkbox" role="switch" checked>
       </div>
-      <div class="f-row justify-content:space-between">
+      <div>
         <label for="toggle-6">I'm not sure</label>
-        <input id="toggle-6" type="checkbox" role="switch">
+        <input id="toggle-6" type="checkbox" role="switch" class="indeterminate">
       </div>
     </fieldset>
   </div>
 
-
-  ~~~ html
-  <div class="f-switch">
-    <fieldset class="f-col">
-      <legend>Button toggles</legend>
-      <button type="button" aria-pressed="false">
-        Toggle me
-      </button>
-      <button type="button" aria-pressed="true">
-        But not me
-      </button>
-    </fieldset>
-    <fieldset class="f-col">
-      <legend>Button toggles, flipped</legend>
-      <button type="button" aria-pressed="false" onclick="this.ariaPressed = this.ariaPressed != 'true'">
-        Toggle me
-      </button>
-      <button type="button" aria-pressed="true" onclick="this.ariaPressed = this.ariaPressed != 'true'">
-        But not me
-      </button>
-    </fieldset>
-  </div>
-  ~~~
-
-  <div class="f-switch">
-    <fieldset class="f-col">
-      <legend>Button toggles</legend>
-      <button type="button" aria-pressed="false">
-        Toggle me
-      </button>
-      <button type="button" aria-pressed="true">
-        But not me
-      </button>
-    </fieldset>
-    <fieldset class="f-col">
-      <legend>Button toggles, flipped</legend>
-      <button type="button" aria-pressed="false" onclick="this.ariaPressed = this.ariaPressed != 'true'">
-        Toggle me
-      </button>
-      <button type="button" aria-pressed="true" onclick="this.ariaPressed = this.ariaPressed != 'true'">
-        But not me
-      </button>
-    </fieldset>
-  </div>
-
-  <strong>TODO</strong>
-  <ul>
-  <li>RTL
-  <li>Indeterminate state
-  </ul>
+  <script>document.querySelectorAll('.indeterminate').forEach(el => {el.indeterminate = true;})</script>
 </figure>


### PR DESCRIPTION
Looks like this branch accidentally contained two fixes that needed to be implemented back during the addition of `[role=feed]`:

1) There was an orphaned parenthesis in sanitize.css (my mistake)
2) Somehow the `token in tokens` / `token of tokens` thing never got implemented in 19.js. Looks like vim also stripped extra whitespace form the file.

The big feedback I'd appreciate right now is on the markup used. Please refer to the ARIA section of the documentation.

1) Is it acceptable to ask the user to wrap `label + input` and `input + label` with e.g. `.f-row.justify-content:between` ?
2) If so, should we put the onus on the user to use e.g. `<label class="f-row">` if using `label > input`? I don't particularly like that my solution involves specifying `label` selectors in the `aria.css` file, where all the other parent selectors are just `[role=thing]`. It would be nice if I could move them inside the `[role=switch]` block somehow (or not include them).
3) I should add, I don't particularly like that `<label><input>Text</label>` is justified with space between, I would prefer it if the spacing is similar to `input + label`, but I don't think it's possible to distinguish between `<label><input>Text</label>` and `<label>Text<input></label>`, and the latter definitely needs the spacing imo.

Also, I'd be grateful for any stylistic feedback, e.g. if the border is too thick, or if we want some other type of styling to make it look more consistent with the "missing look."

I know the `button` styling is broken right now, wanted to focus on getting the others right first. One question I had there was what the selector should be:

1) `button[role=switch][aria-pressed]`
2) `[role=switch][aria-pressed]`
3) `[aria-pressed]`

I think (3) goes out the window because e.g. the collapsing navbar component uses `[aria-pressed]` (with `.iconbutton`) and shouldn't be styled like a toggle.