### PR TITLE
Print grid

### DIFF
--- a/src/grid.css
+++ b/src/grid.css
@@ -92,3 +92,31 @@
     [data-rows\@l^="11 "]  { grid-row-start:   11 }    [data-rows\@l$=" 11"] { grid-row-end:    12 }   [data-rows\@l="11"] { grid-row:    11 }
     [data-rows\@l^="12 "]  { grid-row-start:   12 }    [data-rows\@l$=" 12"] { grid-row-end:    13 }   [data-rows\@l="12"] { grid-row:    12 }
 }
+
+@media print {
+    [data-cols\@p^="1 " ] { grid-column-start: 1  }    [data-cols\@p$=" 1" ] { grid-column-end: 2  }   [data-cols\@p="1" ] { grid-column: 1  }
+    [data-cols\@p^="2 " ] { grid-column-start: 2  }    [data-cols\@p$=" 2" ] { grid-column-end: 3  }   [data-cols\@p="2" ] { grid-column: 2  }
+    [data-cols\@p^="3 " ] { grid-column-start: 3  }    [data-cols\@p$=" 3" ] { grid-column-end: 4  }   [data-cols\@p="3" ] { grid-column: 3  }
+    [data-cols\@p^="4 " ] { grid-column-start: 4  }    [data-cols\@p$=" 4" ] { grid-column-end: 5  }   [data-cols\@p="4" ] { grid-column: 4  }
+    [data-cols\@p^="5 " ] { grid-column-start: 5  }    [data-cols\@p$=" 5" ] { grid-column-end: 6  }   [data-cols\@p="5" ] { grid-column: 5  }
+    [data-cols\@p^="6 " ] { grid-column-start: 6  }    [data-cols\@p$=" 6" ] { grid-column-end: 7  }   [data-cols\@p="6" ] { grid-column: 6  }
+    [data-cols\@p^="7 " ] { grid-column-start: 7  }    [data-cols\@p$=" 7" ] { grid-column-end: 8  }   [data-cols\@p="7" ] { grid-column: 7  }
+    [data-cols\@p^="8 " ] { grid-column-start: 8  }    [data-cols\@p$=" 8" ] { grid-column-end: 9  }   [data-cols\@p="8" ] { grid-column: 8  }
+    [data-cols\@p^="9 " ] { grid-column-start: 9  }    [data-cols\@p$=" 9" ] { grid-column-end: 10 }   [data-cols\@p="9" ] { grid-column: 9  }
+    [data-cols\@p^="10 "] { grid-column-start: 10 }    [data-cols\@p$=" 10"] { grid-column-end: 11 }   [data-cols\@p="10"] { grid-column: 10 }
+    [data-cols\@p^="11 "] { grid-column-start: 11 }    [data-cols\@p$=" 11"] { grid-column-end: 12 }   [data-cols\@p="11"] { grid-column: 11 }
+    [data-cols\@p^="12 "] { grid-column-start: 12 }    [data-cols\@p$=" 12"] { grid-column-end: 13 }   [data-cols\@p="12"] { grid-column: 12 }
+
+    [data-rows\@p^="1 " ]  { grid-row-start:   1  }    [data-rows\@p$=" 1" ] { grid-row-end:    2  }   [data-rows\@p="1" ] { grid-row:    1  }
+    [data-rows\@p^="2 " ]  { grid-row-start:   2  }    [data-rows\@p$=" 2" ] { grid-row-end:    3  }   [data-rows\@p="2" ] { grid-row:    2  }
+    [data-rows\@p^="3 " ]  { grid-row-start:   3  }    [data-rows\@p$=" 3" ] { grid-row-end:    4  }   [data-rows\@p="3" ] { grid-row:    3  }
+    [data-rows\@p^="4 " ]  { grid-row-start:   4  }    [data-rows\@p$=" 4" ] { grid-row-end:    5  }   [data-rows\@p="4" ] { grid-row:    4  }
+    [data-rows\@p^="5 " ]  { grid-row-start:   5  }    [data-rows\@p$=" 5" ] { grid-row-end:    6  }   [data-rows\@p="5" ] { grid-row:    5  }
+    [data-rows\@p^="6 " ]  { grid-row-start:   6  }    [data-rows\@p$=" 6" ] { grid-row-end:    7  }   [data-rows\@p="6" ] { grid-row:    6  }
+    [data-rows\@p^="7 " ]  { grid-row-start:   7  }    [data-rows\@p$=" 7" ] { grid-row-end:    8  }   [data-rows\@p="7" ] { grid-row:    7  }
+    [data-rows\@p^="8 " ]  { grid-row-start:   8  }    [data-rows\@p$=" 8" ] { grid-row-end:    9  }   [data-rows\@p="8" ] { grid-row:    8  }
+    [data-rows\@p^="9 " ]  { grid-row-start:   9  }    [data-rows\@p$=" 9" ] { grid-row-end:    10 }   [data-rows\@p="9" ] { grid-row:    9  }
+    [data-rows\@p^="10 "]  { grid-row-start:   10 }    [data-rows\@p$=" 10"] { grid-row-end:    11 }   [data-rows\@p="10"] { grid-row:    10 }
+    [data-rows\@p^="11 "]  { grid-row-start:   11 }    [data-rows\@p$=" 11"] { grid-row-end:    12 }   [data-rows\@p="11"] { grid-row:    11 }
+    [data-rows\@p^="12 "]  { grid-row-start:   12 }    [data-rows\@p$=" 12"] { grid-row-end:    13 }   [data-rows\@p="12"] { grid-row:    12 }
+}

--- a/www/docs/A0-grid.md
+++ b/www/docs/A0-grid.md
@@ -35,6 +35,8 @@ add `@s` (small, &le;768px) or `@l` (large, &ge;1024px) to the end of the attrib
 : Element will take 1 column in small screens,
   2 columns on medium screens and 3 on large screens
 
+To change the layout for printing, add `@p` to the end of the attributes.
+
 <figure>
 
   ~~~ html


### PR DESCRIPTION
It seems like browsers use a small viewport for printed material and I'd like to be able to print PDFs whose layout differs from a mobile one.

As a side note, should we consider adding some other printer friendly styles?