### PR TITLE
Add [type] support to <ol> breadcrumbs.

### DIFF
--- a/src/components.css
+++ b/src/components.css
@@ -111,12 +111,13 @@ details,
         padding-inline-start: 0;
     }
     & :is(ul, ol):not([type]) {
-        list-style: none;
+        list-style-type: "";
     }
 
     & li {
         display: inline list-item;
         &:not(:last-child)::after {
+            content: var(--separator, var(--breadcrumb-page)) / '';
             content: var(--separator, var(--breadcrumb-page));
             display: inline;
         }

--- a/src/components.css
+++ b/src/components.css
@@ -97,7 +97,15 @@ details,
 }
 
 .breadcrumbs[aria-label] {
-	font-family: var(--secondary-font);
+
+    font-family: var(--secondary-font);
+
+    &:has([aria-current="page"]) {
+      --separator: var(--breadcrumb-page);
+    }
+    &:has([aria-current="step"]) {
+      --separator: var(--breadcrumb-step);
+    }
 
     & ul, & ol {
         padding-inline-start: 0;
@@ -109,8 +117,7 @@ details,
     & li {
         display: inline list-item;
         &:not(:last-child)::after {
-            content: ' / ' / '';
-            content: ' / ';
+            content: var(--separator, var(--breadcrumb-page));
             display: inline;
         }
     }

--- a/src/components.css
+++ b/src/components.css
@@ -100,20 +100,22 @@ details,
 	font-family: var(--secondary-font);
 
     & ul, & ol {
-        list-style: none;
         padding-inline-start: 0;
+    }
+    & :is(ul, ol):not([type]) {
+        list-style: none;
     }
 
     & li {
-        display: inline;
-        &+li::before {
+        display: inline list-item;
+        &:not(:last-child)::after {
             content: ' / ' / '';
             content: ' / ';
             display: inline;
         }
     }
 
-    & [aria-current="page"] {
+    & [aria-current="page"], & [aria-current="step"] {
         font-weight: bold;
     }
 }

--- a/src/main.css
+++ b/src/main.css
@@ -233,7 +233,6 @@ ul {
 }
 
 ol {
-	list-style: decimal;
 }
 
 dl {

--- a/src/variables.css
+++ b/src/variables.css
@@ -45,7 +45,11 @@
   --display-font: var(--secondary-font); /* Headings */
 	--mono-font: 'M Plus Code Latin', monospace, monospace; /* monospace twice stops browsers from
 		shrinking this */
-	
+
+  /* Markers */
+  --breadcrumb-page: ' / ';
+  --breadcrumb-step: ' › ';
+
 	/* Density */
 	--density: 1;
 

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -177,7 +177,8 @@ Add <dfn>`.breadcrumbs`</dfn> to a `<nav>` element. Use an `<ul>` or  `<ol>` of
 links inside. Don't forget to add an `aria-label`.
 
 Add the attribute `aria-current=page` (or `step`) to the link representing the current
-page or step (if any).
+page or step (if any). The separator will be set to either `--breadcrumb-page` or `--breadcrumb-step`
+depending on whether `aria-current=page` or `aria-current=step` is used.
 
 <figure>
 
@@ -212,7 +213,7 @@ If you want to preserve the `<ol>` numbering, use the `type` attribute.
   <header class="packed">
     <strong class="<h1>">Checkout</strong>
     <nav class=breadcrumbs aria-label="Breadcrumbs">
-      <ol type="i">
+      <ol type="1">
         <li><a href="#">Cart</a></li>
         <li><a href="#" aria-current=step>Account</a></li>
         <li>Info</li>
@@ -226,7 +227,7 @@ If you want to preserve the `<ol>` numbering, use the `type` attribute.
   <header class="packed">
     <strong class="<h1>">Checkout</strong>
     <nav class=breadcrumbs aria-label="Breadcrumbs">
-      <ol type="i">
+      <ol type="1">
         <li><a href="#">Cart</a></li>
         <li><a href="#" aria-current=step>Account</a></li>
         <li>Info</li>

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -176,10 +176,12 @@ element will house the rest of the page. See this example:
 Add <dfn>`.breadcrumbs`</dfn> to a `<nav>` element. Use an `<ul>` or  `<ol>` of
 links inside. Don't forget to add an `aria-label`.
 
-Add the attribute `aria-current=page` to the link representing the current page
-(if any).
+Add the attribute `aria-current=page` (or `step`) to the link representing the current
+page or step (if any).
 
 <figure>
+
+  ~~~ html
   <nav class=breadcrumbs aria-label="Breadcrumbs">
     <ol>
       <li><a href="#">Home</a></li>
@@ -189,6 +191,50 @@ Add the attribute `aria-current=page` to the link representing the current page
       <li><a href="#" aria-current=page>Quit Sibelius</a></li>
     </ol>
   </nav>
+  ~~~
+
+  <nav class=breadcrumbs aria-label="Breadcrumbs">
+    <ol>
+      <li><a href="#">Home</a></li>
+      <li><a href="#">User</a></li>
+      <li><a href="#">Advanced</a></li>
+      <li><a href="#">New All</a></li>
+      <li><a href="#" aria-current=page>Quit Sibelius</a></li>
+    </ol>
+  </nav>
+</figure>
+
+If you want to preserve the `<ol>` numbering, use the `type` attribute.
+
+<figure>
+
+  ~~~ html
+  <header class="packed">
+    <h1>Checkout</h1>
+    <nav class=breadcrumbs aria-label="Breadcrumbs">
+      <ol type="i">
+        <li><a href="#">Cart</a></li>
+        <li><a href="#" aria-current=step>Account</a></li>
+        <li>Info</li>
+        <li>Payment</li>
+        <li>Review</li>
+      </ol>
+    </nav>
+  </header>
+  ~~~
+
+  <header class="packed">
+    <h1>Checkout</h1>
+    <nav class=breadcrumbs aria-label="Breadcrumbs">
+      <ol type="i">
+        <li><a href="#">Cart</a></li>
+        <li><a href="#" aria-current=step>Account</a></li>
+        <li>Info</li>
+        <li>Payment</li>
+        <li>Review</li>
+      </ol>
+    </nav>
+  </header>
 </figure>
 
 

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -210,7 +210,7 @@ If you want to preserve the `<ol>` numbering, use the `type` attribute.
 
   ~~~ html
   <header class="packed">
-    <h1>Checkout</h1>
+    <strong class="<h1>">Checkout</strong>
     <nav class=breadcrumbs aria-label="Breadcrumbs">
       <ol type="i">
         <li><a href="#">Cart</a></li>
@@ -224,7 +224,7 @@ If you want to preserve the `<ol>` numbering, use the `type` attribute.
   ~~~
 
   <header class="packed">
-    <h1>Checkout</h1>
+    <strong class="<h1>">Checkout</strong>
     <nav class=breadcrumbs aria-label="Breadcrumbs">
       <ol type="i">
         <li><a href="#">Cart</a></li>

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -139,8 +139,8 @@ classes; these will be listed in the documentation for that class.
 <dfn>`--breadcrumb-page`</dfn> {#var-breadcrumb-page}
 :   The default separator for breadcrumbs.
 
-<dfn>`--breadcrumb-step`</dfn> {#var-breadcrumb-page}
-:   The separator for breadcrumbs that use `[aria-current=page]`.
+<dfn>`--breadcrumb-step`</dfn> {#var-breadcrumb-step}
+:   The separator for breadcrumbs that use `[aria-current=step]`.
 
 ## Density
 

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -134,6 +134,14 @@ classes; these will be listed in the documentation for that class.
     </div>
 
 
+## Markers
+
+<dfn>`--breadcrumb-page`</dfn> {#var-breadcrumb-page}
+:   The default separator for breadcrumbs.
+
+<dfn>`--breadcrumb-step`</dfn> {#var-breadcrumb-page}
+:   The separator for breadcrumbs that use `[aria-current=page]`.
+
 ## Density
 
 <dfn>`--density`</dfn> {#var-density}


### PR DESCRIPTION
Allow users to opt in to numbers in `<ol>` breadcrumbs via the `[type]` attribute.