### PR TITLE
Add aria-tabs custom element

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -1,11 +1,10 @@
-
-[role="tablist"] {
+aria-tablist, [role="tablist"] {
     display: flex;
     gap: .5ch;
     scrollbar-width: thin;
 }
 
-[role="tab"][role="tab"] {
+aria-tab, [role="tab"] {
     all: initial;
 
 	font-family: var(--secondary-font);
@@ -41,7 +40,7 @@
     }
 }
 
-[role="tabpanel"] {
+aria-tabpanel, [role="tabpanel"] {
     /* SEE components/box.css */
 
     margin-block-start: 0;

--- a/src/components.css
+++ b/src/components.css
@@ -3,6 +3,7 @@
 /* defined elsewhere */
 [role=menu],
 .sidebar-layout > header,
+aria-tabpanel,
 [role=tabpanel],
 figure,
 details,

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -3,9 +3,7 @@
 //@deno-types=./19.ts
 import { $, $$, on, off, halts, attr, next, prev, asHtml, hotkey, identify, dispatch } from "./19.js"
 
-// TODO: Do we need to worry about MutationObserver?
-// TODO: Could we add null safety to attr()?
-// TODO: Is there a better way to do display=block
+
 export class ariaTablist extends HTMLElement {
   /* Custom element implementation of the Tabs Pattern as specified by the
    * ARIA Authoring Practices Guide (APG).

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,90 +1,175 @@
 /// a tabs library.
 
 //@deno-types=./19.ts
-import { $, $$, on, attr, next, prev, asHtml, hotkey, behavior, makelogger, identify, dispatch } from "./19.js";
+import { $, $$, on, off, halts, attr, next, prev, asHtml, hotkey, identify, dispatch } from "./19.js"
 
-const ilog = makelogger("tabs");
+// TODO: Do we need to worry about MutationObserver?
+// TODO: Could we add null safety to attr()?
+// TODO: Is there a better way to do display=block
+export class ariaTablist extends HTMLElement {
+  /* Custom element implementation of the Tabs Pattern as specified by the
+   * ARIA Authoring Practices Guide (APG).
+   *
+   * https://www.w3.org/WAI/ARIA/apg/patterns/tabs/
+   *
+   */
 
-/** 
- * @param {Element} tablist
- * @returns {HTMLElement[]}
- */
-const tabsOf = tablist => $$(tablist, "[role=tab]");
+  static sTab = ":is(aria-tab, [role=tab])"
+  static sCurrentTab = ":is(aria-tab, [role=tab])[aria-selected=true]"
 
-/** 
- * @param {Element} tablist
- * @returns {HTMLElement | null}
- */
-const currentTab = tablist => $(tablist, "[role=tab][aria-selected=true]");
+  /**
+   * @returns {HTMLElement[]}
+   */
+  get tabs() { return $$(this, ariaTablist.sTab) }
 
-/** 
- * @param {Element} tab
- * @param {import("./19.ts").Root} root
- * @returns {HTMLElement | null}
- */
-const tabPanelOf = (tab, root) => {
-  const id = attr(tab, "aria-controls");
-  if (id === null) return console.error("Tab", tab, "has no associated tabpanel"), null;
-  return root.getElementById(id);
+  /**
+   * @returns {HTMLElement | null}
+   */
+  get currentTab() { return $(this, ariaTablist.sCurrentTab) }
+
+  focusCurrentTab = () => this.currentTab?.focus()
+  focusNextTab = e => asHtml(next(this, ariaTablist.sTab, asHtml(e.target)))?.focus()
+  focusPrevTab = e => asHtml(prev(this, ariaTablist.sTab, asHtml(e.target)))?.focus()
+  focusFirstTab = () => this.tabs.at(0)?.focus()
+  focusLastTab = () => this.tabs.at(-1)?.focus()
+
+  setAttributes = () => {
+    this._internals.ariaRole = "tablist"
+    this.tabIndex = 0
+    if (!(this.hasAttribute("aria-labelledby") || this.hasAttribute("aria-label")))
+      console.error("Tablist", this, "has no accessible name (aria-label or aria-labelledby)");
+  }
+
+  setInteractions = () => {
+    this.eventListeners = {
+      "focus": on(this, "focus", this.focusCurrentTab),
+      "keydown": on(this, "keydown", hotkey({
+        "ArrowRight": this.focusNextTab,
+        "ArrowLeft": this.focusPrevTab,
+        "Home": halts("default", this.focusFirstTab),
+        "End": halts("default", this.focusLastTab),
+      }))
+    }
+  }
+
+  removeInteractions = () => {
+    for (const eventType in this.eventListeners) {
+      off(this.eventListeners[eventType])
+      delete this.eventListeners[eventType]
+    }
+  }
+
+  constructor() {
+    super()
+    this._internals = this.attachInternals()
+  }
+
+  connectedCallback() {
+    this.setAttributes()
+    this.setInteractions()
+
+    this.currentTab?.switchTab({ focusTab: false })
+  }
+
+  disconnectedCallback() {
+    this.removeInteractions()
+  }
+
 }
 
-/** 
- * @param {import("./19.ts").Root} root
- * @param {Element} tablist
- * @param {HTMLElement | null} tab
- * @returns {void}
- */
-const switchTab = (root, tablist, tab, { focusTab = true } = {}) => {
-  if (!tab) return;
-  const curtab = currentTab(tablist);
+export class ariaTab extends HTMLElement {
 
-  if (curtab) {
-    attr(curtab, { ariaSelected: false, tabindex: -1 });
-    const tabpanel = tabPanelOf(curtab, root);
-    if (tabpanel) tabpanel.hidden = true;
+  /**
+   * @returns {HTMLElement | null}
+   */
+  get tablist() { return this.closest('aria-tablist') }
+
+  /**
+   * @returns {HTMLElement | null}
+   */
+  get tabpanel() { return document.getElementById(attr(this, "aria-controls")) }
+
+  /**
+   * @returns {void}
+   */
+  switchTab = ({ focusTab = true } = {}) => {
+    const curtab = this.tablist?.currentTab
+
+    if (curtab) {
+      attr(curtab, { ariaSelected: false, tabindex: -1 })
+      curtab.tabpanel?.setAttribute("hidden", true)
+    }
+
+    attr(this, { ariaSelected: true, tabindex: 0 })
+    this.tabpanel?.removeAttribute("hidden")
+
+    if (focusTab) this.focus()
+    this.tablist?.setAttribute("tabindex", -1)
+
+    dispatch(curtab, "missing-switch-away", { to: this })
+    dispatch(this, "missing-switch-to", { from: curtab })
+    dispatch(this.tablist, "missing-change", { from: curtab, to: this })
   }
-  attr(tab, { ariaSelected: true, tabindex: 0 });
-  
-  const tabpanel = tabPanelOf(tab, root);
-  if (tabpanel) tabpanel.hidden = false;
 
-  if (focusTab) tab.focus();
+  setAttributes = () => {
+    this._internals.ariaRole = "tab"
+    this.tabIndex = -1
+    this.tabpanel?.setAttribute("aria-labelledby", identify(this))
 
-  tablist.tabIndex = -1;
+    if (attr(this, "aria-controls") === null)
+      console.error("Tab", this, "has no associated tabpanel");
+  }
 
-  dispatch(curtab, "missing-switch-away", { to: tab })
-  dispatch(tab, "missing-switch-to", { from: curtab })
-  dispatch(tablist, "missing-change", { from: curtab, to: tab })
-};
+  setInteractions = () => {
+    this.eventListeners = {
+      "click": on(this, "click", this.switchTab),
+      "focus": on(this, "focus", this.switchTab),
+    }
+  }
 
-/**
- * https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
- */
-export const tablist = behavior("[role=tablist]", (tablist, { root }) => {
-  if (!(tablist instanceof HTMLElement)) return;
-  tablist.tabIndex = 0;
-  tabsOf(tablist).forEach(tab => {
-    tab.tabIndex = -1;
-    tabPanelOf(tab, root).setAttribute("aria-labelledby", identify(tab));
-  });
-  if (!(tablist.hasAttribute("aria-labelledby") || tablist.hasAttribute("aria-label")))
-    console.error("Tab list", tablist, "has no accessible name (aria-label or aria-labelledby)");
-  
-  switchTab(root, tablist, currentTab(tablist), { focusTab: false });
+  removeInteractions = () => {
+    for (const eventType in this.eventListeners) {
+      off(this.eventListeners[eventType])
+      delete this.eventListeners[eventType]
+    }
+  }
 
-  on(tablist, "focus", _ => currentTab(tablist)?.focus());
+  constructor() {
+    super()
+    this._internals = this.attachInternals()
+  }
 
-  on(tablist, "click",   e => switchTab(root, tablist, asHtml(asHtml(e.target)?.closest("[role=tab]"))));
-  on(tablist, "focusin", e => switchTab(root, tablist, asHtml(asHtml(e.target)?.closest("[role=tab]"))));
+  connectedCallback() {
+    this.setAttributes()
+    this.setInteractions()
+  }
 
-  on(tablist, "keydown", hotkey({
-    "ArrowRight": e => asHtml(next(tablist, "[role=tab]", asHtml(e.target)))?.focus(),
-    "ArrowLeft":  e => asHtml(prev(tablist, "[role=tab]", asHtml(e.target)))?.focus(),
-    "Home": _ => tabsOf(tablist).at(0)?.focus(),
-    "End": _ => tabsOf(tablist).at(-1)?.focus(),
-  }));
-})
+  disconnectedCallback() {
+    this.removeInteractions()
+  }
 
-tablist(document);
-export default tablist;
+}
 
+export class ariaTabPanel extends HTMLElement {
+
+  setAttributes = () => {
+    this._internals.ariaRole = "tabpanel"
+    this.style.display = "block"
+  }
+
+  constructor() {
+    super()
+    this._internals = this.attachInternals()
+  }
+
+  connectedCallback() {
+    this.setAttributes()
+  }
+
+}
+
+
+// Must define elements in this order
+customElements.define("aria-tabpanel", ariaTabPanel)
+customElements.define("aria-tab", ariaTab)
+customElements.define("aria-tablist", ariaTablist)

--- a/src/layout.css
+++ b/src/layout.css
@@ -57,6 +57,7 @@
     .box, 
     [role=menu],
     .sidebar-layout > header,
+    aria-tabpanel,
     [role=tabpanel],
     figure,
     details,

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -13,44 +13,43 @@ Missing.css will style markup based on ARIA roles. We often reference the
 
 ## Tabs
 
-Mark up your tabs using the `tablist`, `tab` and `tabpanel` roles
-appropriately — see [WAI: Tabs][].
+Mark up your tabs using the `aria-tablist`, `aria-tab` and `aria-tabpanel` custom elements.
+For reference, see [WAI: Tabs][].
 
 To get the actual behavior of an accessible tabset, you can use [Missing.js &sect; Tabs](/docs/js#tabs).
 
 <figure>
 
   ~~~ html
-  <div role="tablist" aria-label="Tabs example">
-    <button role="tab" aria-controls="servers" aria-selected="true"
-      >Servers</button>
-    <button role="tab" aria-controls="channels"
-      >Channels</button>
-    <button role="tab" aria-controls="users"
-      >Users</button>
-  </div>
+  <aria-tablist aria-label="Tabs example">
+    <aria-tab aria-controls="servers" aria-selected="true"
+      >Servers</aria-tab>
+    <aria-tab aria-controls="channels"
+      >Channels</aria-tab>
+    <aria-tab aria-controls="users"
+      >Users</aria-tab>
+  </aria-tablist>
 
-  <div id="servers"         role="tabpanel">...</div>
-  <div id="channels" hidden role="tabpanel">...</div>
-  <div id="users"    hidden role="tabpanel">...</div>
+  <aria-tabpanel id="servers"        >...</aria-tabpanel>
+  <aria-tabpanel id="channels" hidden>...</aria-tabpanel>
+  <aria-tabpanel id="users"    hidden>...</aria-tabpanel>
   ~~~
 
 </figure>
 
 <script type="module" src="/dist/js/tabs.js"></script>
 
-<div role="tablist" aria-label="Tabs example">
-  <button role="tab" aria-controls="servers" aria-selected="true"
-    >Servers</button>
-  <button role="tab" aria-controls="channels"
-    >Channels</button>
-  <button role="tab" aria-controls="users"
-    >Users</button>
-</div>
-
-<div id="servers"         role="tabpanel">This is tab 1. <strong>JavaScript sold separately!</strong></div>
-<div id="channels" hidden role="tabpanel">You are enjoying tab 2.</div>
-<div id="users"    hidden role="tabpanel"><img alt="placeholder cat" src="https://biber.denizaksimsek.com/img/IMG_2022-07-05_07-16-48-400.webp"></div>
+<aria-tablist aria-label="Tabs example">
+  <aria-tab aria-controls="servers" aria-selected="true"
+    >Servers</aria-tab>
+  <aria-tab aria-controls="channels"
+    >Channels</aria-tab>
+  <aria-tab aria-controls="users"
+    >Users</aria-tab>
+</aria-tablist>
+<aria-tabpanel id="servers"        >This is tab 1. <strong>JavaScript sold separately!</strong></aria-tabpanel>
+<aria-tabpanel id="channels" hidden>You are enjoying tab 2.</aria-tabpanel>
+<aria-tabpanel id="users"    hidden><img alt="placeholder cat" src="https://biber.denizaksimsek.com/img/IMG_2022-07-05_07-16-48-400.webp"></aria-tabpanel>
 
 [WAI: Tabs]: https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 
@@ -184,7 +183,6 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
   </aria-feed>
   ~~~
 
-  <div>
   <script type="module" src="/dist/js/feed.js"></script>
   <aria-feed>
     <article class="box" aria-labelledby="article-1-label">


### PR DESCRIPTION
Migrated the existing `tablist` behavior to the following custom elements: `<aria-tablist>`, `<aria-tab>`, and `<aria-tabpanel>`.

A few questions:

* Is there a better way to set the styling of `aria-tabpanel` to have `display: block`? The current implementation results in `<aria-tabpanel style="display: block">`, which I'm not crazy with. I'm not really familiar with shadow dom methods, but based on some research it seemed like a lot of code to just set the display value. 
* Could we consider adding null safety to `attr()`? That way I could use it for lines 98, 102, and 105 of `tabs.js`.
* Do we need to worry about MutationObserver if someone appends a new tab? Or will `ariaTab.setAttributes()` take care of that?

Any other feedback would be greatly appreciated. Thanks!