### PR TITLE
Adopt `<meta name=color-scheme>`

### DIFF
--- a/src/variables.css
+++ b/src/variables.css
@@ -7,7 +7,7 @@
 	--graphical-fg: var(--plain-graphical-fg); /* Graphical elements. Will not
 		be used as a text color. */
 	
-	--plain-fg: light-dark(var(--blue-10), var(--blue-2)); /* TODO: is blue-10 a typo? */
+	--plain-fg: light-dark(var(--blue-10), var(--blue-2));
 	--info-fg: light-dark(var(--blue-11), var(--blue-2));
 	--ok-fg: light-dark(var(--green-11), var(--green-2));
 	--bad-fg: light-dark(var(--red-11), var(--red-2));
@@ -20,7 +20,6 @@
 	--warn-graphical-fg: light-dark(var(--yellow-6), var(--yellow-6));
 	
 	--bg: light-dark(var(--gray-0), var(--gray-12)); /* Page background. */
-  /* TODO: Should box-bg both be --plain-bg? */
 	--box-bg: light-dark(var(--plain-bg), var(--gray-10)); /* Background for blocks: cards, admonitions etc. */
 	--interactive-bg: light-dark(var(--gray-4), var(--gray-8)); /* Background for interactive elements */
 

--- a/src/variables.css
+++ b/src/variables.css
@@ -1,38 +1,38 @@
-
 :root {
 	/* Colors */
-	--fg: var(--gray-12); /* Text. */
-	--muted-fg: var(--gray-10); /* Secondary text color. Will be
+	--fg: light-dark(var(--gray-12), var(--gray-0)); /* Text. */
+	--muted-fg: light-dark(var(--gray-10), var(--gray-2)); /* Secondary text color. Will be
 		used with a background of --c-bg and --c-bg-2 -- check contrast! */
-	--faded-fg: var(--gray-6); /* Disabled text color. */
+	--faded-fg: light-dark(var(--gray-6), var(--gray-7)); /* Disabled text color. */
 	--graphical-fg: var(--plain-graphical-fg); /* Graphical elements. Will not
 		be used as a text color. */
 	
-	--plain-fg: var(--blue-10);
-	--info-fg: var(--blue-11);
-	--ok-fg: var(--green-11);
-	--bad-fg: var(--red-11);
-	--warn-fg: var(--yellow-11);
+	--plain-fg: light-dark(var(--blue-10), var(--blue-2)); /* TODO: is blue-10 a typo? */
+	--info-fg: light-dark(var(--blue-11), var(--blue-2));
+	--ok-fg: light-dark(var(--green-11), var(--green-2));
+	--bad-fg: light-dark(var(--red-11), var(--red-2));
+	--warn-fg: light-dark(var(--yellow-11), var(--yellow-2));
 
-	--plain-graphical-fg: var(--gray-6);
-	--info-graphical-fg: var(--blue-6);
-	--ok-graphical-fg: var(--green-6);
-	--bad-graphical-fg: var(--red-6);
-	--warn-graphical-fg: var(--yellow-6);
+	--plain-graphical-fg: light-dark(var(--gray-6), var(--blue-6));
+	--info-graphical-fg: light-dark(var(--blue-6), var(--blue-6));
+	--ok-graphical-fg: light-dark(var(--green-6), var(--green-6));
+	--bad-graphical-fg: light-dark(var(--red-6), var(--red-6));
+	--warn-graphical-fg: light-dark(var(--yellow-6), var(--yellow-6));
 	
-	--bg: var(--gray-0); /* Page background. */
-	--box-bg: var(--plain-bg); /* Background for blocks: cards, admonitions etc. */
-	--interactive-bg: var(--gray-4); /* Background for interactive elements */
+	--bg: light-dark(var(--gray-0), var(--gray-12)); /* Page background. */
+  /* TODO: Should box-bg both be --plain-bg? */
+	--box-bg: light-dark(var(--plain-bg), var(--gray-10)); /* Background for blocks: cards, admonitions etc. */
+	--interactive-bg: light-dark(var(--gray-4), var(--gray-8)); /* Background for interactive elements */
 
-	--plain-bg: var(--gray-1);
-	--info-bg: var(--blue-1);
-	--ok-bg: var(--green-1);
-	--bad-bg: var(--red-1);
-	--warn-bg: var(--yellow-1);
+	--plain-bg: light-dark(var(--gray-1), var(--gray-11));
+	--info-bg: light-dark(var(--blue-1), var(--blue-12));
+	--ok-bg: light-dark(var(--green-1), var(--green-12));
+	--bad-bg: light-dark(var(--red-1), var(--red-12));
+	--warn-bg: light-dark(var(--yellow-1), var(--yellow-12));
 
-	--accent: var(--blue-10); /* Accent color. Will be used *as a text color* with a
+	--accent: light-dark(var(--blue-10), var(--blue-2)); /* Accent color. Will be used *as a text color* with a
 		background of --c-bg and --c-bg-2 -- check contrast! */
-	--muted-accent: var(--blue-7); /* Muted accent color. Will not be used for text. */
+	--muted-accent: light-dark(var(--blue-7), var(--blue-5)); /* Muted accent color. Will not be used for text. */
 
 	/* Lengths */
 	--rhythm: 1.4rem; /* Vertical rhythm, line height. */
@@ -71,64 +71,11 @@
 			) / 2);                      /* Divide by 2: there are two page margins */
 }
 
-/* Enable dark theme independently of os preferences*/
-:root.-dark-theme {
-	--fg: var(--gray-0);
-	--muted-fg: var(--gray-2);
-	--faded-fg: var(--gray-7);
-	--plain-bg: var(--gray-11);
-	--info-bg: var(--blue-12);
-	--ok-bg: var(--green-12);
-	--bad-bg: var(--red-12);
-	--warn-bg: var(--yellow-12);
-	--plain-graphical-fg: var(--blue-6);
-	--info-graphical-fg: var(--blue-6);
-	--ok-graphical-fg: var(--green-6);
-	--bad-graphical-fg: var(--red-6);
-	--warn-graphical-fg: var(--yellow-6);
-	--bg: var(--gray-12);
-	--box-bg: var(--gray-10);
-	--interactive-bg: var(--gray-8);
-	--plain-fg: var(--blue-2);
-	--info-fg: var(--blue-2);
-	--ok-fg: var(--green-2);
-	--bad-fg: var(--red-2);
-	--warn-fg: var(--yellow-2);
-	--accent: var(--blue-2);
-	--muted-accent: var(--blue-5)
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not(.-no-dark-theme) {
-    	--fg: var(--gray-0);
-    	--muted-fg: var(--gray-2);
-    	--faded-fg: var(--gray-7);
-
-		--plain-bg: var(--gray-11);
-    	--info-bg: var(--blue-12);
-    	--ok-bg: var(--green-12);
-    	--bad-bg: var(--red-12);
-    	--warn-bg: var(--yellow-12);
-
-		--plain-graphical-fg: var(--blue-6);
-		--info-graphical-fg: var(--blue-6);
-		--ok-graphical-fg: var(--green-6);
-		--bad-graphical-fg: var(--red-6);
-		--warn-graphical-fg: var(--yellow-6);
-
-    	--bg: var(--gray-12);
-    	--box-bg: var(--gray-10);
-    	--interactive-bg: var(--gray-8);
-
-		--plain-fg: var(--blue-2);
-    	--info-fg: var(--blue-2);
-    	--ok-fg: var(--green-2);
-    	--bad-fg: var(--red-2);
-    	--warn-fg: var(--yellow-2);
-
-    	--accent: var(--blue-2);
-    	--muted-accent: var(--blue-5);
-    }
+/* Respect the depreciated .-dark-theme and .-no-dark-theme classes */
+:root:not(:has(meta[name=color-scheme])) {
+  &.-dark-theme    { color-scheme: dark  }
+  &.-no-dark-theme { color-scheme: light }
+  &:not(.-dark-theme, .-no-dark-theme) { color-scheme: light dark }
 }
 
 * {

--- a/src/variables.css
+++ b/src/variables.css
@@ -70,7 +70,7 @@
 			) / 2);                      /* Divide by 2: there are two page margins */
 }
 
-/* Respect the depreciated .-dark-theme and .-no-dark-theme classes */
+/* Respect the deprecated .-dark-theme and .-no-dark-theme classes */
 :root:not(:has(meta[name=color-scheme])) {
   &.-dark-theme    { color-scheme: dark  }
   &.-no-dark-theme { color-scheme: light }

--- a/src/variables.css
+++ b/src/variables.css
@@ -20,8 +20,9 @@
 	--warn-graphical-fg: light-dark(var(--yellow-6), var(--yellow-6));
 	
 	--bg: light-dark(var(--gray-0), var(--gray-12)); /* Page background. */
-	--box-bg: light-dark(var(--plain-bg), var(--gray-10)); /* Background for blocks: cards, admonitions etc. */
+	--box-bg: light-dark(var(--plain-bg), var(--plain-bg)); /* Background for blocks: cards, admonitions etc. */
 	--interactive-bg: light-dark(var(--gray-4), var(--gray-8)); /* Background for interactive elements */
+	--pressed-interactive-bg: light-dark(var(--bg), var(--bg)); /* Background for interactive elements with [aria-pressed|expanded=true] */
 
 	--plain-bg: light-dark(var(--gray-1), var(--gray-11));
 	--info-bg: light-dark(var(--blue-1), var(--blue-12));

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -7,8 +7,8 @@ url: ./variables/
 
 We use several CSS variables that you can override to customize your site. You
 can create multiple classes that set these variables and switch between them to
-create multiple themes, or use the `prefers-color-scheme` @media query to
-create a dark theme.
+create multiple themes. When overriding color variables, be sure to use the
+`light-dark()` CSS function in order to preserve the light/dark theme functionality.
 
 This is a reference of all the variables you can set on the root `<html>`
 element. There are a few more that are used with specific components or utility

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -138,11 +138,11 @@ To customize the theme independently of `prefers-color-scheme` you can use the f
 
 ### Dark theme
 
-~~Add the <dfn>`.-dark-theme`</dfn> class to your root element to use the dark theme.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Use `<meta name=color-scheme content=dark>` instead.
+~~Add the <dfn>`.-dark-theme`</dfn> class to your root element to use the dark theme.~~ **Deprecated:**{.bad .color} Will be removed in version 2.0. Use `<meta name=color-scheme content=dark>` instead.
 
 ### No dark theme
 
-~~Add the <dfn>`.-no-dark-theme`</dfn> class to your root element to use the light theme.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Use `<meta name=color-scheme content=light>` instead.
+~~Add the <dfn>`.-no-dark-theme`</dfn> class to your root element to use the light theme.~~ **Deprecated:**{.bad .color} Will be removed in version 2.0. Use `<meta name=color-scheme content=light>` instead.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>:</v-h></sub-title>Theme toggle markup</figcaption>

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -133,17 +133,55 @@ The following classes can be used to make one element look like another:
 
 ## Theme selection
 
-Missing.css, by default applies a light or dark theme based on `prefers-color-scheme`.
-To customize the theme independently of the `prefers-color-scheme` you can use
-the following classes:
+By default, missing.css applies a light or dark theme based on the visitor's OS settings.
+To customize the theme independently of `prefers-color-scheme` you can use the following:
 
 ### Dark theme
 
-Add the <dfn>`.-dark-theme`</dfn> class to your root element to use the dark theme.
+~~Add the <dfn>`.-dark-theme`</dfn> class to your root element to use the dark theme.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Use `<meta name=color-scheme content=dark>` instead.
 
 ### No dark theme
 
-Add the <dfn>`.-no-dark-theme`</dfn> class to your root element to use the light theme.
+~~Add the <dfn>`.-no-dark-theme`</dfn> class to your root element to use the light theme.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Use `<meta name=color-scheme content=light>` instead.
+
+<figure>
+<figcaption><sub-title class="allcaps">Example<v-h>:</v-h></sub-title>Theme toggle markup</figcaption>
+
+  ~~~ css
+  :root:has([name=theme][value=light]:checked) { color-scheme: light      }
+  :root:has([name=theme][value=dark]:checked)  { color-scheme: dark       }
+  :root:has([name=theme][value=auto]:checked)  { color-scheme: light dark }
+  ~~~
+
+  ~~~ html
+  <fieldset>
+    <legend>Select theme</legend>
+    <div>
+    <div><label><input type=radio name=theme value=light> Light</label></div>
+    <div><label><input type=radio name=theme value=dark> Dark</label></div>
+    <div><label><input type=radio name=theme value=auto> Auto</label></div>
+    </div>
+  </fieldset>
+  ~~~
+
+  <hr>
+
+  <style>
+    :root:has([name=theme][value=light]:checked) { color-scheme: light      }
+    :root:has([name=theme][value=dark]:checked)  { color-scheme: dark       }
+    :root:has([name=theme][value=auto]:checked)  { color-scheme: light dark }
+  </style>
+  <fieldset>
+    <legend>Select theme</legend>
+    <div>
+    <div><label><input type=radio name=theme value=light> Light</label></div>
+    <div><label><input type=radio name=theme value=dark> Dark</label></div>
+    <div><label><input type=radio name=theme value=auto> Auto</label></div>
+    </div>
+  </fieldset>
+
+</figure>
+
 
 ## Reset
 


### PR DESCRIPTION
This PR deprecates the `.-dark-theme` and `.-no-dark-theme` util classes for the `<meta name=color-scheme>` tag. 

A new example of how to use the tag has been added. The deprecated classes still work (although, they won't work on the page with the example because of the style tag the example uses).