### PR TITLE
Depreciate `--rhythm`

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -10,9 +10,9 @@
 
 	font-family: var(--secondary-font);
     
-    padding: 0 calc(var(--rhythm) / 4);
+    padding: 0 calc(var(--rhythm, 1rlh) / 4);
     margin: 0;
-    min-height: var(--rhythm);
+    min-height: var(--rhythm, 1rlh);
     bottom: -1px;
     position: relative;
     
@@ -175,7 +175,7 @@ input[type=checkbox][role=switch] {
     margin-block-end: auto;
   }
   &:not(label > *) {
-    padding-block: calc(var(--gap) / 4 + (var(--rhythm) - 1em) / 2);
+    padding-block: calc(var(--gap) / 4 + (var(--rhythm, 1rlh) - 1em) / 2);
   }
 
   :is(label:has(> &)) {

--- a/src/components.css
+++ b/src/components.css
@@ -132,12 +132,12 @@ details,
 	font-family: var(--secondary-font);
     border: 1px solid var(--accent);
     background: var(--box-bg);
-    border-radius: calc(var(--rhythm) / 2);
-    padding-inline: calc(var(--rhythm) / 2);
+    border-radius: calc(var(--rhythm, 1rlh) / 2);
+    padding-inline: calc(var(--rhythm, 1rlh) / 2);
 }
 
 .navbar {
-	padding: var(--rhythm);
+	padding: var(--rhythm, 1rlh);
 
 	font-family: var(--secondary-font);
 
@@ -184,7 +184,7 @@ details,
 	& nav ul[role="list"] {
 		display: flex;
 		flex-flow: row;
-		gap: var(--rhythm);
+		gap: var(--rhythm, 1rlh);
 		
 		& * { flex-shrink: 0 }
 	}
@@ -240,7 +240,7 @@ button.iconbutton {
 	color: currentcolor;
 	padding: 0;
 	box-shadow: none;
-	line-height: var(--rhythm);
+	line-height: var(--rhythm, 1rlh);
 	font-size: 24px;
 	width: 24px;
 	height: 24px;

--- a/src/layout.css
+++ b/src/layout.css
@@ -137,7 +137,7 @@
 
 .big {
     font-size: 1.4em;
-    line-height: calc(1.5 * var(--rhythm));
+    line-height: calc(1.5 * var(--rhythm, 1rlh));
 }
 
 /**/

--- a/src/main.css
+++ b/src/main.css
@@ -9,7 +9,7 @@
 
 html {
 	font-family: var(--main-font);
-	line-height: var(--rhythm);
+	line-height: var(--rhythm, 1.4rem);
 
 	background: var(--bg);
 	color: var(--fg);
@@ -33,8 +33,8 @@ nav {
 
 aside {
 	font-size: .8em;
-	line-height: calc(var(--rhythm) * 2 / 3);
-	--gap: calc(var(--rhythm) * var(--density) * 2 / 3);
+	line-height: calc(var(--rhythm, 1rlh) * 2 / 3);
+	--gap: calc(var(--rhythm, 1rlh) * var(--density) * 2 / 3);
 
 	border-block: 1px solid var(--graphical-fg);
 	padding-block: var(--gap);
@@ -62,7 +62,7 @@ aside {
 		border-inline-start: 1px solid var(--muted-fg);
 		border-radius: 0;
 		padding: 0;
-		padding-inline-start: var(--rhythm);
+		padding-inline-start: var(--rhythm, 1rlh);
 		font-style: italic;
 		color: var(--accent);
 	}
@@ -80,26 +80,26 @@ h1, h2, h3, h4, h5, h6,
 h1, .\<h1\> {
 	font-size: 2em;
 	text-transform: none;
-	line-height: calc(2 * var(--rhythm));
+	line-height: calc(2 * var(--rhythm, 1rlh));
 	letter-spacing: 0;
 }
 
 h2, .\<h2\> {
 	font-size: 1.6em;
 	text-transform: none;
-	line-height: calc(1.5 * var(--rhythm));
+	line-height: calc(1.5 * var(--rhythm, 1rlh));
 	letter-spacing: 0;
 }
 
 h3, .\<h3\> {
 	font-size: 1.17em;
-	line-height: calc(1 * var(--rhythm));
+	line-height: calc(1 * var(--rhythm, 1rlh));
 }
 
 h4, .\<h4\>, h5, .\<h5\>, h6, .\<h6\> {
 	font-size: 1em;
 	text-transform: none;
-	line-height: calc(1 * var(--rhythm));
+	line-height: calc(1 * var(--rhythm, 1rlh));
 	letter-spacing: 0;
 	margin-block-start: var(--gap);
 }
@@ -144,14 +144,14 @@ header {
 footer {
 	font-family: var(--secondary-font);
 	font-size: .8em;
-	line-height: calc(var(--rhythm) * 2 / 3);
+	line-height: calc(var(--rhythm, 1rlh) * 2 / 3);
 	border-block-start: 1px solid var(--graphical-fg);
 }
 
 body > header,
 body > footer,
 main + footer {
-	padding: var(--rhythm) calc((100% - var(--eff-line-length)) / 2)
+	padding: var(--rhythm, 1rlh) calc((100% - var(--eff-line-length)) / 2)
 }
 
 address {
@@ -183,7 +183,7 @@ hr {
 pre {
 	font-family: var(--mono-font);
 	font-size: .9em;
-	line-height: var(--rhythm);
+	line-height: var(--rhythm, 1rlh);
 	tab-size: 2;
 
 	margin: var(--gap) 0;
@@ -199,7 +199,7 @@ blockquote {
 	margin-block: var(--gap);
 	
 	font-size: 1.1em;
-	line-height: var(--rhythm);
+	line-height: var(--rhythm, 1rlh);
 	font-style: italic;
 
 	border-inline-start: 1px solid var(--graphical-fg);
@@ -216,7 +216,7 @@ blockquote {
 }
 
 ul, ol {
-	padding-inline-start: var(--rhythm);
+	padding-inline-start: var(--rhythm, 1rlh);
 	margin-block: var(--gap);
 
 	& & {
@@ -244,7 +244,7 @@ dl {
 	}
 
 	dd {
-		margin-inline-start: var(--rhythm);
+		margin-inline-start: var(--rhythm, 1rlh);
 	}
 
 li::marker {
@@ -318,7 +318,7 @@ small[role="note"] {
 	padding-inline: 1.5ch 1ch;
 
 	margin-inline-end: calc(1em - var(--sidenote-width));
-	margin-block-end: var(--rhythm);
+	margin-block-end: var(--rhythm, 1rlh);
 
 	font-family: var(--secondary-font);
 
@@ -339,7 +339,7 @@ small[role="note"] {
 
 small, .\<small\> {
 	font-size: .8em;
-	line-height: calc(var(--rhythm) * 2 / 3);
+	line-height: calc(var(--rhythm, 1rlh) * 2 / 3);
 }
 
 s {
@@ -462,7 +462,7 @@ td, th {
 	vertical-align: top;
 	
 	&:not(:last-child) {
-		padding-inline-end: var(--rhythm);
+		padding-inline-end: var(--rhythm, 1rlh);
 	}
 }
 
@@ -493,14 +493,14 @@ label :is(input, select):not([specificity-hack]) {
 ):not(.\<a\>),
 input::file-selector-button {
 	display: inline-block;
-	padding: 0 calc(var(--rhythm) / 4);
+	padding: 0 calc(var(--rhythm, 1rlh) / 4);
 	vertical-align: middle;
 	box-sizing: border-box;
 	
 	font-size: .8rem;
 	line-height: 1.125em;
 	font-family: var(--secondary-font);
-	min-height: var(--rhythm);
+	min-height: var(--rhythm, 1rlh);
 
 	background: var(--interactive-bg);
 	color: var(--fg);
@@ -576,10 +576,10 @@ strong > input:disabled::file-selector-button {
 	}
 
 	&.big {
-		min-block-size: calc(1.5 * var(--rhythm));
+		min-block-size: calc(1.5 * var(--rhythm, 1rlh));
 		font-size: 1rem;
-		padding-inline: calc(.5 * var(--rhythm));
-		line-height: var(--rhythm);
+		padding-inline: calc(.5 * var(--rhythm, 1rlh));
+		line-height: var(--rhythm, 1rlh);
 	}
 
 	&:disabled {
@@ -604,7 +604,7 @@ input[type="datetime-local"],
 input[type="number"],
 select,
 textarea {
-	padding: calc(var(--rhythm) / 4);
+	padding: calc(var(--rhythm, 1rlh) / 4);
 	vertical-align: top;
 	
 	font-size: 1rem;
@@ -637,7 +637,7 @@ input[type="range"] {
 input[type="color"] {
 	padding: 0;
 	margin: 0;
-	height: calc(1.5 * var(--rhythm));
+	height: calc(1.5 * var(--rhythm, 1rlh));
 
 	border: none;
 	background: none;
@@ -646,7 +646,7 @@ input[type="color"] {
 input[type="file"] {
 	padding: calc(var(--gap) / 4) 0;
 	font: inherit;
-	line-height: calc(var(--rhythm) / 2);
+	line-height: calc(var(--rhythm, 1rlh) / 2);
 	&::file-selector-button {
 		margin-block: .1em 0;
 		margin-inline-end: 1ch;

--- a/src/variables.css
+++ b/src/variables.css
@@ -35,7 +35,6 @@
 	--muted-accent: var(--blue-7); /* Muted accent color. Will not be used for text. */
 
 	/* Lengths */
-	--rhythm: 1.4rem; /* Vertical rhythm, line height. */
 	--line-length: 40rem; /* Maximum line length for prose. */
 	--border-radius: .2rem;
 
@@ -59,7 +58,7 @@
 	/* Do not set these. */
 	--eff-line-length: /* Effective line length for prose. */
 		min(
-			calc( var(--full-width) - (2 * var(--rhythm)) ),
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
 			var(--line-length)
 		);
 
@@ -132,7 +131,7 @@
 }
 
 * {
-	--gap: calc(var(--rhythm) * var(--density));
+	--gap: calc(var(--rhythm, 1rlh) * var(--density));
 }
 
 * {

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -99,7 +99,7 @@ classes; these will be listed in the documentation for that class.
 ## Lengths
 
 <dfn>~~`--rhythm`~~</dfn> {#var-rhythm}
-:   ~~Vertical rhythm, line height.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Set a value for the `line-height` property on the `html` element instead.
+:   ~~Vertical rhythm, line height.~~ **Deprecated:**{.bad .color} Will be removed in version 2.0. Set a value for the `line-height` property on the `html` element instead.
 
 <dfn>`--line-length`</dfn> {#var-line-length}
 :   Maximum line length for prose.

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -98,8 +98,8 @@ classes; these will be listed in the documentation for that class.
 
 ## Lengths
 
-<dfn>`--rhythm`</dfn> {#var-rhythm}
-:   Vertical rhythm, line height.
+<dfn>~~`--rhythm`~~</dfn> {#var-rhythm}
+:   ~~Vertical rhythm, line height.~~ <strong class="bad color">Depreciated:</strong> Will be removed in version 2.0. Set a value for the `line-height` property on the `html` element instead.
 
 <dfn>`--line-length`</dfn> {#var-line-length}
 :   Maximum line length for prose.


### PR DESCRIPTION
- Added a note in the docs about the depreciation.
- Replaced all instances of `var(--rhythm)` with `var(--rhythm, 1rlh)`
- Remove the definition of `--rhythm` in `variables.css`
- Set `html { line-height: var(--rhythm, 1.4rem) }` in `main.css`