### PR TITLE
reimplement tabs as custom elements using new tag() function, focusgroup

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -1,28 +1,28 @@
 
-[role="tablist"] {
+aria-tablist, [role="tablist"] {
     display: flex;
     gap: .5ch;
 }
 
-[role="tab"]:not([specificity-hack]) {
+aria-tab, [role="tab"]:not([specificity-hack]) {
     all: initial;
     color-scheme: light dark;
 
 	font-family: var(--secondary-font);
-    
+
     padding: 0 calc(var(--rhythm, 1rlh) / 4);
     margin: 0;
     min-height: var(--rhythm, 1rlh);
     bottom: calc(-1 * var(--border-block-start-width));
     position: relative;
-    
+
     color: var(--fg);
     border: var(--border-block-start-width) var(--border-block-start-style) var(--graphical-fg);
     background: var(--interactive-bg);
-    
+
     border-start-start-radius: var(--tab-border-radius);
     border-start-end-radius: var(--tab-border-radius);
-    
+
     &:active, &[aria-selected="true"] {
         background: var(--box-bg);
         border-block-end: var(--border-block-start-width) var(--border-block-start-style) transparent;
@@ -40,9 +40,10 @@
     }
 }
 
-[role="tabpanel"] {
+aria-tabpanel, [role="tabpanel"] {
     /* SEE components/box.css */
 
+    display: block;
     margin-block-start: 0;
     border-start-start-radius: 0;
     border-start-end-radius: 0;
@@ -54,7 +55,7 @@
     position: absolute;
 
     z-index: 10;
-    
+
     padding: calc(var(--gap) / 2) 0;
     margin: 1px 0 0 0;
 
@@ -102,7 +103,7 @@
 
         background: var(--temporary-bg);
         color: var(--temporary-fg);
-        
+
         > * {
             --bg: var(--temporary-bg);
             --fg: var(--temporary-fg);

--- a/src/aria.css
+++ b/src/aria.css
@@ -22,7 +22,8 @@ aria-tab, [role="tab"]:not([specificity-hack]) {
     border-start-start-radius: var(--tab-border-radius);
     border-start-end-radius: var(--tab-border-radius);
 
-    &:active, &[aria-selected="true"] {
+    &:active,
+    &[aria-selected="true"] {
         background: var(--box-bg);
         border-block-end: var(--border-block-start-width) var(--border-block-start-style) transparent;
     }
@@ -78,36 +79,37 @@ aria-tabpanel, [role="tabpanel"] {
     }
 }
 
-[role=listbox] {
+aria-listbox, [role=listbox] {
     /* This has been removed from docs, but we keep the styling here as a
      * reference for future implementation.
      */
     list-style: none;
 
-    [role=option] {
+    aria-option, [role=option] {
         margin-inline: calc(-1 * var(--gap));
         padding-inline: var(--gap);
         border-radius: 0;
-    }
 
-    [role=option][aria-selected=true] {
-        background: var(--interactive-bg);
-    }
+        &[aria-selected=true],
+        &[aria-checked=true] {
+            background: var(--interactive-bg);
+        }
 
-    [role=option].active {
-        --temporary-bg: var(--accent);
-        --temporary-fg: var(--bg);
-        --temporary-accent: var(--muted-accent); /* TODO: was `parent-var` */
-        --temporary-muted-accent: var(--box-bg); /* TODO: was `parent-var` */
+        &.active {
+            --temporary-bg: var(--accent);
+            --temporary-fg: var(--bg);
+            --temporary-accent: var(--muted-accent); /* TODO: was `parent-var` */
+            --temporary-muted-accent: var(--box-bg); /* TODO: was `parent-var` */
 
-        background: var(--temporary-bg);
-        color: var(--temporary-fg);
+            background: var(--temporary-bg);
+            color: var(--temporary-fg);
 
-        > * {
-            --bg: var(--temporary-bg);
-            --fg: var(--temporary-fg);
-            --accent: var(--temporary-accent);
-            --muted-accent: var(--temporary-muted-accent);
+            > * {
+                --bg: var(--temporary-bg);
+                --fg: var(--temporary-fg);
+                --accent: var(--temporary-accent);
+                --muted-accent: var(--temporary-muted-accent);
+            }
         }
     }
 }

--- a/src/aria.css
+++ b/src/aria.css
@@ -1,4 +1,3 @@
-
 aria-tablist, [role="tablist"] {
     display: flex;
     gap: .5ch;

--- a/src/components.css
+++ b/src/components.css
@@ -3,6 +3,7 @@
 /* defined elsewhere */
 [role=menu],
 .sidebar-layout > header,
+aria-tabpanel,
 [role=tabpanel],
 figure,
 details,

--- a/src/components.css
+++ b/src/components.css
@@ -68,7 +68,7 @@ details,
 }
 
 
-.tool-bar, [role=toolbar] {
+.tool-bar, [role=toolbar], aria-toolbar {
 	display: flex;
 	flex-flow: row wrap;
 	gap: calc(var(--gap) / 2);

--- a/src/components.css
+++ b/src/components.css
@@ -3,8 +3,7 @@
 /* defined elsewhere */
 [role=menu],
 .sidebar-layout > header,
-aria-tabpanel,
-[role=tabpanel],
+aria-tabpanel, [role=tabpanel],
 figure,
 details,
 :where(dialog) {

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -520,34 +520,45 @@ export function behavior(selector, init) {
 export function tag(name, options, init) {
   if (typeof options === "function") { init = options; options = {} }
   const {
-    base = HTMLElement,
     internals = {},
-    formAssociated = false,
+    mixins = [],
     observedAttributes = [],
-    mutationOptions = {},
+    css = null,
   } = options
-  return class extends base {
+  const Base = mixins.reduce((Base, Mixin) =>
+    Mixin(Base), options.Base ?? HTMLElement)
+
+  return class extends Base {
+
+    static observedAttributes = [
+      ...(Base.observedAttributes || []),
+      ...observedAttributes,
+    ]
+    static inits = [...(Base.inits || []), init]
+
     constructor() {
       super()
+
       if (!this.internals) this.internals = this.attachInternals()
       Object.assign(this.internals, internals)
-      init(this)
-      if (Object.keys(mutationOptions).length)
-        this.observer = new MutationObserver((records, observer) =>
-          records.forEach(r => dispatch(this, `mutation:${r.type}`, r)))
+
+      if (!this.shadowRoot) {
+        this.attachShadow({ mode: "open" })
+        this.shadowRoot.innerHTML = `<slot></slot>`
+      }
+      if (css) this.shadowRoot.adoptedStyleSheets.push(css)
+
+      this.constructor.inits.forEach(init => init(this))
+
+      this.constructor.observedAttributes.filter((attr) =>
+        !this.hasAttribute(attr)
+      ).forEach((attr) =>
+        dispatch(this, `attribute:${attr}`, { value: null })
+      )
     }
 
-    // adapted from https://github.com/kgscialdone/facet/blob/master/facet.js
-    static observedAttributes = observedAttributes
-
-    connectedCallback() {
-      dispatch(this, 'connected')
-      this.observer?.observe(this, mutationOptions)
-    }
-    disconnectedCallback() {
-      dispatch(this, 'disconnected')
-      this.observer?.disconnect()
-    }
+    connectedCallback() { dispatch(this, 'connected') }
+    disconnectedCallback() { dispatch(this, 'disconnected') }
     connectedMoveCallback() { dispatch(this, 'connectedMove') }
     adoptedCallback() { dispatch(this, 'adopted') }
     attributeChangedCallback(name, oldValue, newValue) {
@@ -555,14 +566,47 @@ export function tag(name, options, init) {
       dispatch(this, `attributeChanged:${name}`, { oldValue, newValue })
       dispatch(this, `attribute:${name}`, { value: newValue })
     }
-    formAssociatedCallback(form) { dispatch(this, 'formAssociated', { form }) }
-    formDisabledCallback(disabled) { dispatch(this, 'formDisabled', { disabled }) }
-    formResetCallback() { dispatch(this, 'formReset') }
-    formStateRestoreCallback(state, mode) {
-      dispatch(this, 'formStateRestore', { state, mode }) }
+
+    attr(name, value) {
+      const curValue = this[name] || this.internals[name]
+      if (value === undefined)
+        return curValue
+      else
+        return this[name] = value, curValue
+    }
 
     static define() { customElements.define(name, this) }
-    static install(el) { init(el) }
+
+  }
+}
+
+export function mixin(options, init) {
+  if (typeof options === "function") { init = options; options = {} }
+  const {
+    internals = {},
+    observedAttributes = [],
+    css = null,
+  } = options
+  return (Super) => class extends Super {
+
+    static observedAttributes = [
+      ...(Super.observedAttributes || []),
+      ...observedAttributes,
+    ]
+    static inits = [...(Super.inits || []), init]
+
+    constructor() {
+      super()
+
+      if (!this.internals) this.internals = this.attachInternals()
+      Object.assign(this.internals, internals)
+
+      if (!this.shadowRoot) {
+        this.attachShadow({ mode: "open" })
+        this.shadowRoot.innerHTML = `<slot></slot>`
+      }
+      if (css) this.shadowRoot.adoptedStyleSheets.push(css)
+    }
   }
 }
 

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -544,6 +544,7 @@ export function tag(name, options, init) {
       dispatch(this, 'formStateRestore', { state, mode }) }
 
     static define() { customElements.define(name, this) }
+    static install(el) { init(el) }
   }
 }
 

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -521,6 +521,7 @@ export function tag(name, options, init) {
   const {
     base = HTMLElement,
     internals = {},
+    formAssociated = false,
     observedAttributes = [],
     mutationOptions = {},
   } = options
@@ -530,7 +531,7 @@ export function tag(name, options, init) {
       if (!this.internals) this.internals = this.attachInternals()
       Object.assign(this.internals, internals)
       init(this)
-      if (mutationOptions.length)
+      if (Object.keys(mutationOptions).length)
         this.observer = new MutationObserver((records, observer) =>
           records.forEach(r => dispatch(this, `mutation:${r.type}`, r)))
     }
@@ -540,7 +541,7 @@ export function tag(name, options, init) {
 
     connectedCallback() {
       dispatch(this, 'connected')
-      this.observer?.observe(this, observedMutations)
+      this.observer?.observe(this, mutationOptions)
     }
     disconnectedCallback() {
       dispatch(this, 'disconnected')

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -456,8 +456,7 @@ export function hotkey(hotkeys) {
     const [key, modifiers] = parse(hotkeySpec);
     (handlers[key.toLowerCase()] ??= new Array(8))[modifiers] = handler;
   }
-
-  return (/** @type {KeyboardEvent} */ e) => handlers[e.key]?.[modifiersOf(e)]?.(e);
+  return (/** @type {KeyboardEvent} */ e) => handlers[e.key.toLowerCase()]?.[modifiersOf(e)]?.(e);
 }
 
 /**

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -94,6 +94,8 @@ export function traverse(
   const { wrap = true } = options;
 
   const advance = /** @type {const} */(`${direction}ElementSibling`);
+  
+  const descend = direction === "next" ? $ : (el, sel) => $$(el, sel).at(-1)
 
   const wrapIt = () => {
     // If wrapping is disabled.

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -134,7 +134,7 @@ export function traverse(
     cursor = /** @type {HTMLElement} */ (cursor[advance]); // 1 to 2 to 3, r to 4
     const found = cursor.matches(selector)
       ? cursor // 4
-      : $(cursor, selector); // asterisks
+      : descend(cursor, selector); // asterisks
     if (found) return found;
   }
 }

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -120,7 +120,7 @@ export function traverse(
   // start at 1). Then, having run out of siblings, we move up (as many times
   // as needed) before advancing, ending up at 4.
   //
-  // To "test" an element, ee call Element#matches, then if that returns false,
+  // To "test" an element, we call Element#matches, then if that returns false,
   // querySelector. The querySelector call is how the items marked with
   // asterisks can be checked.
   let cursor = current;
@@ -518,20 +518,36 @@ export function behavior(selector, init) {
  */
 export function tag(name, options, init) {
   if (typeof options === "function") { init = options; options = {} }
-  const { base = HTMLElement, observedAttributes = [] } = options
+  const {
+    base = HTMLElement,
+    internals = {},
+    observedAttributes = [],
+    mutationOptions = {},
+  } = options
   return class extends base {
     constructor() {
       super()
       if (!this.internals) this.internals = this.attachInternals()
+      Object.assign(this.internals, internals)
       init(this)
-      observedAttributes.forEach((attr) =>
-        dispatch(this, `attribute:${attr}`, { value: this.getAttribute(attr) }))
+      if (mutationOptions.length)
+        this.observer = new MutationObserver((records, observer) =>
+          records.forEach(r => dispatch(this, `mutation:${r.type}`, r)))
     }
 
-    // snatched from https://github.com/kgscialdone/facet/blob/master/facet.js
-    observedAttributes = observedAttributes
-    connectedCallback() { dispatch(this, 'connected') }
-    disconnectedCallback() { dispatch(this, 'disconnected') }
+    // adapted from https://github.com/kgscialdone/facet/blob/master/facet.js
+    static observedAttributes = observedAttributes
+
+    connectedCallback() {
+      dispatch(this, 'connected')
+      this.observer?.observe(this, observedMutations)
+    }
+    disconnectedCallback() {
+      dispatch(this, 'disconnected')
+      this.observer?.disconnect()
+    }
+    connectedMoveCallback() { dispatch(this, 'connectedMove') }
+    adoptedCallback() { dispatch(this, 'adopted') }
     attributeChangedCallback(name, oldValue, newValue) {
       dispatch(this, 'attributeChanged', { name, oldValue, newValue })
       dispatch(this, `attributeChanged:${name}`, { oldValue, newValue })

--- a/src/js/19.js
+++ b/src/js/19.js
@@ -439,11 +439,11 @@ export function hotkey(hotkeys) {
     ~~(e.altKey && alt) | ~~(e.ctrlKey && ctrl) |
     ~~(e.metaKey && meta) | ~~(e.shiftKey && shift);
   const parse = /** @returns {[string, number]} */ (/** @type {string} */ hotkeySpec) => {
-      const
-        tokens = hotkeySpec.split("+"), key = /** @type {string} */ (tokens.pop());
+      const tokens = hotkeySpec.toLowerCase().split("+");
+      const key = /** @type {string} */ (tokens.pop());
       let modifiers = 0 | 0;
       for (const token of tokens)
-        switch (token.toLowerCase()) {
+        switch (token) {
           case "alt": modifiers |= alt; break;
           case "ctrl": modifiers |= ctrl; break;
           case "meta": modifiers |= meta; break;
@@ -454,7 +454,7 @@ export function hotkey(hotkeys) {
 
   for (const [hotkeySpec, handler] of Object.entries(hotkeys)) {
     const [key, modifiers] = parse(hotkeySpec);
-    (handlers[key] ??= new Array(8))[modifiers] = handler;
+    (handlers[key.toLowerCase()] ??= new Array(8))[modifiers] = handler;
   }
 
   return (/** @type {KeyboardEvent} */ e) => handlers[e.key]?.[modifiersOf(e)]?.(e);

--- a/src/js/checkable.js
+++ b/src/js/checkable.js
@@ -1,0 +1,40 @@
+//@deno-types=./19.ts
+import { makelogger, mixin, on } from "./19.js"
+
+const ilog = makelogger("checkable")
+
+const roles = /** @type {const} */ ([
+  "checkbox",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "radio",
+  "switch",
+])
+
+export const CheckableMixin = mixin(
+  {
+    internals: { ariaChecked: "false" },
+    observedAttributes: ["aria-checked"],
+  },
+  (el) => {
+
+    const role = () => (el.internals || el).role
+
+    if (!roles.includes(role()))
+      return console.error(el, `role must be one of ${roles}; got ${role()}.`)
+
+    el.internals.states.add("checkable")
+    if (role() === "checkbox" || role() === "menuitemcheckbox")
+      el.internals.states.add("tristate")
+
+    on(el, "connected", (e) => {
+      const isChecked = (el.ariaChecked || el.hasAttribute("checked"))
+      const isMenuitem = (role().startsWith("menuitem"))
+      el.tabIndex = (!isMenuitem || isChecked) ? 0 : -1
+    })
+
+    on(el, "attribute:aria-checked", (e) => {
+      dispatch(el, "changed", {}, { bubbles: true })
+    })
+  }
+)

--- a/src/js/commandbutton.js
+++ b/src/js/commandbutton.js
@@ -1,5 +1,5 @@
+//@deno-types=./19.ts
 import { attr, identify, on, halt, halts, behavior, makelogger } from "./19.js"
-
 
 const ilog = makelogger("command-button")
 
@@ -13,7 +13,6 @@ const commandTable = /** @type {const} */ ({
   "show-modal": "showModal",
 })
 
-
 export class CommandEvent extends Event {
   constructor(type, options = { cancelable: true }) {
     const { command, source } = options
@@ -24,7 +23,6 @@ export class CommandEvent extends Event {
     })
   }
 }
-
 
 export const commandButton = behavior(
   "button[command][commandfor]",
@@ -92,6 +90,5 @@ export const commandButton = behavior(
 
   },
 )
-
 
 commandButton(document)

--- a/src/js/commandbutton.js
+++ b/src/js/commandbutton.js
@@ -1,0 +1,97 @@
+import { attr, identify, on, halt, halts, behavior, makelogger } from "./19.js"
+
+
+const ilog = makelogger("command-button")
+
+const commandTable = /** @type {const} */ ({
+  // ref: https://html.spec.whatwg.org/#attr-button-command
+  "toggle-popover": "togglePopover",
+  "show-popover": "showPopover",
+  "hide-popover": "hidePopover",
+  "close": "close",
+  "request-close": "requestClose",
+  "show-modal": "showModal",
+})
+
+
+export class CommandEvent extends Event {
+  constructor(type, options = { cancelable: true }) {
+    const { command, source } = options
+    super("command", options)
+    Object.defineProperties(this, {
+      command: { value: command, configurable: false, enumerable: false, writable: false },
+      source:  { value: source,  configurable: false, enumerable: false, writable: false },
+    })
+  }
+}
+
+
+export const commandButton = behavior(
+  "button[command][commandfor]",
+  (button, { root }) => {
+
+    // Polyfill not necessary if UA implements the functionality
+    if ("command" in button && "commandForElement" in button) return
+
+    // Submit and reset buttons cannot invoke a command
+    if (button.form && button.type !== "button") {
+      console.warn(
+        "Buttons associated with forms that include command or commandfor attributes are ambiguous, " +
+        "and require a type=button attribute. No action will be taken."
+      )
+      on(button, "click", (e) => halt("default propagation", e))
+    }
+
+    // Reflect attributes
+    Object.defineProperties(button, {
+      command: {
+        get: () => attr(button, "command") || "",
+        set: (value) => attr(button, "command", value),
+        configurable: true, enumerable: true,
+      },
+      commandForElement: {
+        get: () => button.getRootNode().getElementById(attr(button, "commandfor")),
+        set: (el) => attr(button, "commandfor", el instanceof Element ? identify(el) : null),
+        configurable: true, enumerable: true,
+      }
+    })
+
+    // Handle ARIA
+    // ref: https://www.w3.org/TR/html-aam-1.0/#att-command-popovers
+    //      https://www.w3.org/TR/html-aam-1.0/#att-command-dialogs
+    //      https://www.w3.org/TR/html-aam-1.0/#att-commandfor
+    if (
+      button.command.endsWith("popover")
+      && button.commandForElement?.matches("[popover]")
+      && !button.commandForElement?.contains(button)
+    ) {
+      attr(button, {
+        "aria-expanded": String(button.commandForElement.matches(":popover-open")),
+        "aria-details": button.commandForElement.id,
+      })
+      on(button.commandForElement, "toggle", (e) =>
+        button.ariaExpanded = String(e.newState === "open"))
+    }
+
+    // Handle events
+    on(button, "click", halts("default", (e) => {
+      if (!button.commandForElement) return
+
+      // Attempt to perform the command via method calling
+      const method = button.commandForElement[commandTable[button.command]]
+      if (typeof method === "function")
+        method.call(button.commandForElement)
+      else if (!button.command.startsWith("--"))
+        ilog(`WARNING: unsupported value for "command" attribute: "${button.command}"`)
+
+      // Always dispatch the event
+      const options = { command: button.command, source: button }
+      button.commandForElement.dispatchEvent(new CommandEvent("command", options))
+
+    }))
+
+  },
+)
+
+
+commandButton(document)

--- a/src/js/feed.js
+++ b/src/js/feed.js
@@ -1,85 +1,87 @@
-/// <reference lib="es2022" />
+//@deno-types=./19.ts
+import { $, on, halts, hotkey, traverse, makelogger, tag } from "./19.js"
+import { validate } from "./validate.js"
+import { MutationMixin } from "./mutation.js"
 
-import { $, $$, on, dispatch, halts, attr, next, prev, asHtml, hotkey, behavior, makelogger } from "./19.js"
+const ilog = makelogger("feed")
 
-const ilog = makelogger("feed");
-const sFeed = "[role=feed]";
-const sScopedArticle = ":scope > article, :scope > [role=article]";
-const sArticle = "article, [role=article]";
-const sFocusable = ":is(a, area)[href], :is(button, details, embed, iframe, label, select, textarea):not([disabled]), :is(audio, video)[controls], :is(img, object)[usemap], [tabindex]:not([tabindex='-1'])"
+const keyTable = /** @type {const} */ ({
+  "PageDown": "next",
+  "PageUp": "previous",
+  "Ctrl+End": "after",
+  "Ctrl+Home": "before",
+  "Alt+PageUp": "outside",
+  "Alt+PageDown": "inside",
+})
 
-/**
- * @param {HTMLElement} feed
- * @returns {HTMLElement[]}
- */
-const articles = feed => $$(feed, sScopedArticle);
+const sFocusable = /** @type {const} */ ([
+  "[tabindex]:not([tabindex='-1'])",
+  ":is(a, area)[href]",
+  ":is(audio, video)[controls]",
+  ":is(img, object)[usemap]",
+  ":is(button, details, embed, iframe, label, select, textarea):not([disabled])"
+].join(", "))
 
+const feed = tag(
+  "aria-feed",
+  {
+    internals: {
+      role: "feed",
+      ariaLive: "polite",
+      ariaRelevant: "additions",
+      ariaKeyShortcuts: Object.keys(keyTable).join(" "),
+    },
+    mixins: [
+      MutationMixin({ childList: true }),
+      validate({ name: true, sChildren: ":is(article, [role=article])" }),
+    ],
+  },
+  (feed) => {
+    const register = (article, idx, articles) => {
+      Object.assign(article, {
+        tabIndex: 0,
+        ariaAtomic: "true",
+        ariaPosInSet: idx + 1,
+        ariaSetSize: feed.hasAttribute("infinite") ? -1 : articles.length,
+      })
 
-/**
- * @param {HTMLElement} feed
- * @param {HTMLElement} activeElement
- * @returns {null}
- */
-const focusPreviousArticle = (feed, activeElement) => asHtml(prev(feed, sArticle, activeElement, {wrap: false}))?.focus();
+      if (!article.hasAttribute("aria-labelledby"))
+        console.error(article, "has no accessible name (aria-labelledby)")
+      if (!article.hasAttribute("aria-describedby"))
+        console.warn(article, "has no accessible description (aria-describedby)")
+    }
+    const update = () => [...feed.children].forEach(register)
 
+    const sArticle = "article, [role=article]"
+    const focus = (direction) => {
+      const current = document.activeElement.closest(sArticle)
+      if (!current) return
 
-/**
- * @param {HTMLElement} feed
- * @param {HTMLElement} activeElement
- * @returns {null}
- */
-const focusNextArticle = (feed, activeElement) => asHtml(next(feed, sArticle, activeElement.closest(sArticle), {wrap: false}))?.focus();
+      let dest = null
 
+      if (direction == "inside")
+        dest = $(current, sArticle)
+      else if (direction == "outside")
+        dest = current.parentElement.closest(sArticle)
+      else if (direction == "next" || direction == "previous")
+        dest = traverse(direction, feed, sArticle, current, { wrap: false })
+      else if (direction == "after" || direction == "before") {
+        direction = { after: "next", before: "previous" }[direction]
+        dest = traverse(direction, document.body, sFocusable, feed, { wrap: false })
+      }
+      dest?.focus()
+    }
 
-/**
- * @param {HTMLElement} article
- * @returns {null}
- */
-const focusOutsideFeed = article => asHtml(article.parentElement.closest(sArticle))?.focus();
+    on(feed, "connected", (e) => update())
 
+    on(feed, "mutation:childList", (e) => update())
 
-/**
- * @param {HTMLElement} activeElement
- * @returns {null}
- */
-const focusInsideFeed = activeElement => asHtml($(activeElement.closest(sArticle), sArticle))?.focus();
+    on(feed, "keydown", hotkey(Object.fromEntries(
+      Object.entries(keyTable).map(([key, value]) =>
+        [key, halts("default propagation", (e) => focus(value))]
+      )
+    )))
+  }
+)
 
-
-/**
- * @param {HTMLElement} feed
- * @returns {null}
- */
-const focusBeforeFeed = feed => asHtml(prev(document.body, sFocusable, feed, {}))?.focus();
-
-
-/**
- * @param {HTMLElement} feed
- * @returns {null}
- */
-const focusAfterFeed = feed => asHtml(next(document.body, sFocusable, feed, {}))?.focus();
-
-
-export const feed = behavior(sFeed, (feed, { root }) => {
-
-    if (!(feed instanceof HTMLElement)) return;
-
-    feed.setAttribute("aria-busy", "false");
-    articles(feed).forEach((article, idx, articles) => {
-        article.setAttribute("tabindex", "0");
-        article.setAttribute("aria-posinset", idx + 1);
-        article.setAttribute("aria-setsize", articles.length);
-        if (!(article.hasAttribute("aria-labelledby") || article.hasAttribute("aria-label")))
-            console.error("Article", article, "has no accessible name (aria-label or aria-labelledby)");
-    });
-
-    on(feed, "keydown", hotkey({
-        "PageUp": halts("default propagation", _ => focusPreviousArticle(feed, root.activeElement)),
-        "PageDown": halts("default propagation", _ => focusNextArticle(feed, root.activeElement)),
-        "Alt+PageUp": halts("default", _ => focusOutsideFeed(root.activeElement)),
-        "Alt+PageDown": halts("default", _ => focusInsideFeed(root.activeElement)),
-        "Ctrl+Home": halts("default propagation", _ => focusBeforeFeed(feed)),
-        "Ctrl+End": halts("default propagation", _ => focusAfterFeed(feed)),
-    }));
-});
-
-feed(document);
+feed.define()

--- a/src/js/focusgroup.js
+++ b/src/js/focusgroup.js
@@ -1,0 +1,85 @@
+import { $, $$, on, halt, halts, hotkey, tag, traverse } from "./19.js";
+
+// keyTable[writing-mode][direction][key] => action
+
+const keyTable = /** @type {const} */ ({
+  "horizontal-tb": {
+    "ltr": {
+      "block": { "Up": "previous", "Down": "next" },
+      "inline": { "Left": "previous", "Right": "next" },
+    },
+    "rtl": {
+      "block": { "Up": "previous", "Down": "next" },
+      "inline": { "Right": "previous", "Left": "next" },
+    },
+  },
+  "vertical-lr": {
+    "ltr": {
+      "block": { "Left": "previous", "Right": "next" },
+      "inline": { "Up": "previous", "Down": "next" },
+    },
+    "rtl": {
+      "block": { "Left": "previous", "Right": "next" },
+      "inline": { "Down": "previous", "Up": "next" },
+    },
+  },
+  "vertical-lr": {
+    "ltr": {
+      "block": { "Right": "previous", "Left": "next" },
+      "inline": { "Up": "previous", "Down": "next" },
+    },
+    "rtl": {
+      "block": { "Right": "previous", "Left": "next" },
+      "inline": { "Down": "previous", "Up": "next" },
+    },
+  },
+})
+
+export const focusGroup = tag(
+  "focus-group",
+  { observedAttributes: ["orientation"] },
+  (group) => {
+    const writingMode = () => getComputedStyle(group).writingMode
+    const direction = () => getComputedStyle(group).direction
+    const orientation = () => group.getAttribute("aria-orientation") ?? "inline"
+    const wrapping = () => group.hasAttribute("wrap")
+
+    const movement = (key) =>
+      keyTable[writingMode()][direction()][orientation()][key]
+
+    const current = () => group.contains(document.activeElement)
+      ? document.activeElement
+      : null
+
+    const sMember = "[tabindex]"
+
+    const focusTo = (dest) => {
+      if (!dest) return
+      $$(group, sMember).forEach(member => member.tabIndex = -1)
+      dest.tabIndex = 0
+      dest.focus()
+    }
+
+    on(group, "keydown", hotkey({
+      "Home": (e) => halts("default propagation", e,
+        () => focusTo($(group, sMember))),
+      "End": (e) => halts("default propagation", e,
+        () => focusTo($$(group, sMember).at(-1))),
+    }))
+
+    on(group, "keydown", (e) => {
+      const mvt = e.key.startsWith("Arrow") && movement(e.key.slice(5))
+      if (mvt) {
+        halt("default propagation", e)
+        focusTo(traverse(mvt, group, sMember, current(), { wrap: wrapping() }))
+      }
+    })
+
+    on(group, "focusin", (e) => focusTo(e.target))
+
+    on(group, "attribute:orientation", e =>
+      group.internals.ariaOrientation = orientation())
+  }
+)
+
+focusGroup.define()

--- a/src/js/focusgroup.js
+++ b/src/js/focusgroup.js
@@ -66,7 +66,7 @@ export const focusGroup = tag(
     }
 
     on(group, "connected", (e) => {
-      const members = $$(group, sMembers)
+      const members = $$(group, sMember)
       const initialized = members.find(m => m.tabIndex == 0 || m.autofocus )
       if (members.length && !initialized)
         members[0].tabIndex = 0

--- a/src/js/focusgroup.js
+++ b/src/js/focusgroup.js
@@ -1,4 +1,6 @@
-import { $, $$, attr, on, dispatch, halt, halts, hotkey, tag, traverse, makelogger } from "./19.js"
+//@deno-types=./19.ts
+import { $, $$, css, halt, halts, hotkey, makelogger, mixin, on, tag, traverse } from "./19.js"
+import { validate } from "./validate.js"
 
 const ilog = makelogger("focus-group")
 
@@ -7,56 +9,64 @@ const ilog = makelogger("focus-group")
 const keyTable = /** @type {const} */ ({
   "horizontal-tb": {
     "ltr": {
-      "block": { "Up": "previous", "Down": "next" },
-      "inline": { "Left": "previous", "Right": "next" },
+      "vertical": { "Up": "previous", "Down": "next" },
+      "horizontal": { "Left": "previous", "Right": "next" },
     },
     "rtl": {
-      "block": { "Up": "previous", "Down": "next" },
-      "inline": { "Right": "previous", "Left": "next" },
+      "vertical": { "Up": "previous", "Down": "next" },
+      "horizontal": { "Right": "previous", "Left": "next" },
     },
   },
   "vertical-lr": {
     "ltr": {
-      "block": { "Left": "previous", "Right": "next" },
-      "inline": { "Up": "previous", "Down": "next" },
+      "vertical": { "Left": "previous", "Right": "next" },
+      "horizontal": { "Up": "previous", "Down": "next" },
     },
     "rtl": {
-      "block": { "Left": "previous", "Right": "next" },
-      "inline": { "Down": "previous", "Up": "next" },
+      "vertical": { "Left": "previous", "Right": "next" },
+      "horizontal": { "Down": "previous", "Up": "next" },
     },
   },
   "vertical-rl": {
     "ltr": {
-      "block": { "Right": "previous", "Left": "next" },
-      "inline": { "Up": "previous", "Down": "next" },
+      "vertical": { "Right": "previous", "Left": "next" },
+      "horizontal": { "Up": "previous", "Down": "next" },
     },
     "rtl": {
-      "block": { "Right": "previous", "Left": "next" },
-      "inline": { "Down": "previous", "Up": "next" },
+      "vertical": { "Right": "previous", "Left": "next" },
+      "horizontal": { "Down": "previous", "Up": "next" },
     },
   },
 })
 
-export const focusGroup = tag(
-  "focus-group",
-  { observedAttributes: ["orientation"] },
+export const FocusGroupMixin = mixin(
+  {
+    internals: { ariaOrientation: "horizontal" },
+    observedAttributes: ["aria-orientation"],
+    css: css`
+      :host {
+        display: flex;
+        flex-direction: var(--flex-direction);
+        inline-size: fit-content;
+      }
+      :host(:state(horizontal)) { --flex-direction: row; }
+      :host(:state(vertical)) { --flex-direction: column; }
+    `
+  },
   (group) => {
-    if (!group.hasAttribute("aria-labelledby") && !group.hasAttribute("aria-label"))
-      ilog("ERROR:", group, "has no accessible name (aria-label or aria-labelledby)")
 
     const writingMode = () => getComputedStyle(group).writingMode
     const direction = () => getComputedStyle(group).direction
-    const orientation = () => group.getAttribute("orientation") ?? "inline"
-    const wrapping = () => group.hasAttribute("wrap")
+    const orientation = () => (group.ariaOrientation || group.internals.ariaOrientation)
+    const wrapping = ()  => group.hasAttribute("wrap")
 
     const movement = (key) =>
       keyTable[writingMode()][direction()][orientation()][key]
 
+    const sMember = "[tabindex]:not(:state(focusgroup))"
     const current = () => group.contains(document.activeElement)
       ? document.activeElement
       : null
-
-    const sMember = '[tabindex]:not([focusgroup="none"] *)'
 
     const focusTo = (dest) => {
       if (!dest) return
@@ -65,14 +75,13 @@ export const focusGroup = tag(
       dest.focus()
     }
 
+    group.internals.states.add("focusgroup")
+
     on(group, "connected", (e) => {
       const members = $$(group, sMember)
-      const initialized = members.find(m => m.tabIndex == 0 || m.autofocus )
-      if (members.length && !initialized)
+      const initialized = members.filter(m => m.tabIndex == 0 || m.autofocus)
+      if (members.length && !initialized.length)
         members[0].tabIndex = 0
-
-     if (!group.hasAttribute("orientation"))
-        dispatch(group, "attribute:orientation", {})
     })
 
     on(group, "focusin", (e) => focusTo(e.target))
@@ -85,18 +94,23 @@ export const focusGroup = tag(
     on(group, "keydown", (e) => {
       const mvt = e.key.startsWith("Arrow") && movement(e.key.slice(5))
       if (mvt) {
-        halt("default propagation", e)
+        halt("default", e)
         focusTo(traverse(mvt, group, sMember, current(), { wrap: wrapping() }))
       }
     })
 
-    on(group, "attribute:orientation", (e) => {
-      group.internals.ariaOrientation = {
-        horizontal: { block: "vertical",   inline: "horizontal" },
-        vertical:   { block: "horizontal", inline: "vertical"   },
-      }[writingMode().split("-")[0]][orientation()]
+    on(group, "attribute:aria-orientation", (e) => {
+      const state = orientation()
+      group.internals.states.delete((state === "horizontal") ? "vertical" : state)
+      group.internals.states.add(state)
     })
   }
+)
+
+export const focusGroup = tag(
+  "focus-group",
+  { mixins: [FocusGroupMixin, validate({ label: true })] },
+  (group) => {}
 )
 
 focusGroup.define()

--- a/src/js/focusgroup.js
+++ b/src/js/focusgroup.js
@@ -1,4 +1,6 @@
-import { $, $$, on, halt, halts, hotkey, tag, traverse } from "./19.js";
+import { $, $$, attr, on, dispatch, halt, halts, hotkey, tag, traverse, makelogger } from "./19.js"
+
+const ilog = makelogger("focus-group")
 
 // keyTable[writing-mode][direction][key] => action
 
@@ -23,7 +25,7 @@ const keyTable = /** @type {const} */ ({
       "inline": { "Down": "previous", "Up": "next" },
     },
   },
-  "vertical-lr": {
+  "vertical-rl": {
     "ltr": {
       "block": { "Right": "previous", "Left": "next" },
       "inline": { "Up": "previous", "Down": "next" },
@@ -39,9 +41,12 @@ export const focusGroup = tag(
   "focus-group",
   { observedAttributes: ["orientation"] },
   (group) => {
+    if (!group.hasAttribute("aria-labelledby") && !group.hasAttribute("aria-label"))
+      ilog("ERROR:", group, "has no accessible name (aria-label or aria-labelledby)")
+
     const writingMode = () => getComputedStyle(group).writingMode
     const direction = () => getComputedStyle(group).direction
-    const orientation = () => group.getAttribute("aria-orientation") ?? "inline"
+    const orientation = () => group.getAttribute("orientation") ?? "inline"
     const wrapping = () => group.hasAttribute("wrap")
 
     const movement = (key) =>
@@ -51,7 +56,7 @@ export const focusGroup = tag(
       ? document.activeElement
       : null
 
-    const sMember = "[tabindex]"
+    const sMember = '[tabindex]:not([focusgroup="none"] *)'
 
     const focusTo = (dest) => {
       if (!dest) return
@@ -60,11 +65,21 @@ export const focusGroup = tag(
       dest.focus()
     }
 
+    on(group, "connected", (e) => {
+      const members = $$(group, sMembers)
+      const initialized = members.find(m => m.tabIndex == 0 || m.autofocus )
+      if (members.length && !initialized)
+        members[0].tabIndex = 0
+
+     if (!group.hasAttribute("orientation"))
+        dispatch(group, "attribute:orientation", {})
+    })
+
+    on(group, "focusin", (e) => focusTo(e.target))
+
     on(group, "keydown", hotkey({
-      "Home": (e) => halts("default propagation", e,
-        () => focusTo($(group, sMember))),
-      "End": (e) => halts("default propagation", e,
-        () => focusTo($$(group, sMember).at(-1))),
+      "Home": halts("default propagation", (e) => focusTo($(group, sMember))),
+      "End":  halts("default propagation", (e) => focusTo($$(group, sMember).at(-1))),
     }))
 
     on(group, "keydown", (e) => {
@@ -75,10 +90,12 @@ export const focusGroup = tag(
       }
     })
 
-    on(group, "focusin", (e) => focusTo(e.target))
-
-    on(group, "attribute:orientation", e =>
-      group.internals.ariaOrientation = orientation())
+    on(group, "attribute:orientation", (e) => {
+      group.internals.ariaOrientation = {
+        horizontal: { block: "vertical",   inline: "horizontal" },
+        vertical:   { block: "horizontal", inline: "vertical"   },
+      }[writingMode().split("-")[0]][orientation()]
+    })
   }
 )
 

--- a/src/js/forms.js
+++ b/src/js/forms.js
@@ -1,0 +1,37 @@
+//@deno-types=./19.ts
+import { dispatch, makelogger } from "./19.js"
+
+const ilog = makelogger("forms")
+
+/**
+ * @template T
+ * @param {T} Super
+ * @returns {T}
+ */
+export const FormElementMixin = (Super) => class extends Super {
+
+  static formAssociated = true
+  #value = ""
+
+  constructor() {
+    super()
+    if (!this.internals) this.internals = this.attachInternals()
+  }
+
+  get value() { return this.#value }
+  set value(value) { this.internals.setFormValue(this.#value = value) }
+  get form() { return this.internals.form }
+  get name() { return this.getAttribute('name') }
+  get type() { return this.localName }
+  get validity() { return this.internals.validity }
+  get validationMessage() { return this.internals.validationMessage }
+  get willValidate() { return this.internals.willValidate }
+  checkValidity() { return this.internals.checkValidity() }
+  reportValidity() { return this.internals.reportValidity() }
+
+  formAssociatedCallback(form) { dispatch(this, 'formAssociated', { form }) }
+  formDisabledCallback(disabled) { dispatch(this, 'formDisabled', { disabled }) }
+  formResetCallback() { dispatch(this, 'formReset') }
+  formStateRestoreCallback(state, mode) {
+    dispatch(this, 'formStateRestore', { state, mode }) }
+}

--- a/src/js/listbox.js
+++ b/src/js/listbox.js
@@ -1,0 +1,110 @@
+//@deno-types=./19.ts
+import { $, $$, css, dispatch, makelogger, on, tag } from "./19.js"
+import { validate } from "./validate.js"
+import { FormElementMixin} from "./forms.js"
+import { FocusGroupMixin } from "./focusgroup.js"
+import { TypeAheadMixin } from "./typeahead.js"
+import { SelectableMixin } from "./selectable.js"
+import { MultiSelectMixin } from "./multiselect.js"
+
+const ilog = makelogger("listbox")
+
+export const listbox = tag(
+  "aria-listbox",
+  {
+    internals: { role: "listbox", ariaOrientation: "vertical", ariaMultiSelectable: "false" },
+    mixins: [
+      FormElementMixin,
+      FocusGroupMixin,
+      TypeAheadMixin,
+      MultiSelectMixin,
+      validate({ name: true, sChildren: ":is(aria-optgroup, aria-option)" }),
+    ],
+  },
+  (listbox) => {
+    const sMember = "aria-option"
+    const sSelected = "aria-option[aria-selected=true]"
+
+    const setDefault = () => {
+      $$(listbox, sMember).forEach(o =>
+        o.ariaSelected = o.hasAttribute("selected") ? "true" : null)
+    }
+
+    const setValue = () => {
+      if (listbox.hasAttribute("disabled"))
+        return listbox.value = null
+
+      const data = new FormData()
+      $$(listbox, sSelected).forEach(o =>
+        data.append(listbox.name, o.getAttribute("value")))
+      listbox.value = data
+    }
+
+    on(listbox, "connected", (e) => {
+      if (!$(listbox, "[aria-selected=true]"))
+        setDefault()
+      setValue()
+    })
+
+    on(listbox, "formDisabled", (e) => {
+      listbox.ariaDisabled = (e.detail.disabled) ? "true" : null
+      setValue()
+    })
+
+    on(listbox, "formReset", (e) => {
+      setDefault()
+      setValue()
+    })
+
+    on(listbox, "formStateRestore", (e) => {
+      if (e.detail.mode === "restore") {
+        const values = [...e.detail.state.values()]
+        $$(listbox, sMember).forEach(o =>
+          o.ariaSelected = values.includes(o.getAttribute("value")) ? "true" : null)
+        setValue()
+      }
+    })
+
+    on(listbox, "changed", (e) => setValue())
+  }
+)
+
+export const optgroup = tag(
+  "aria-optgroup",
+  {
+    internals: { role: "group" },
+    mixins: [validate({ sParent: "aria-listbox", sChildren: "aria-option" })],
+    css: css`:host { display: flex; flex-direction: var(--flex-direction) }`,
+    observedAttributes: ["tabindex"],
+  },
+  (optgroup) => {
+    on(optgroup, "attribute:tabindex", (e) => {
+      if (e.detail.value !== null) {
+        optgroup.removeAttribute("tabindex")
+        console.warn(optgroup, "do not support focus. The 'tabindex' attribute has been removed.")
+      }
+    })
+  }
+)
+
+export const option = tag(
+  "aria-option",
+  {
+    internals: { role: "option" },
+    mixins: [
+      SelectableMixin,
+      validate({ sParent: ":is(aria-listbox, aria-optgroup)" }),
+    ],
+    observedAttributes: ["aria-selected"],
+  },
+  (option) => {
+    on(option, "attribute:aria-selected", (e) => {
+      dispatch(option, "changed", {}, { bubbles: true })
+    })
+  },
+)
+
+// Define nested elements first
+option.define()
+optgroup.define()
+listbox.define()

--- a/src/js/listbox.js
+++ b/src/js/listbox.js
@@ -95,13 +95,8 @@ export const option = tag(
       SelectableMixin,
       validate({ sParent: ":is(aria-listbox, aria-optgroup)" }),
     ],
-    observedAttributes: ["aria-selected"],
   },
-  (option) => {
-    on(option, "attribute:aria-selected", (e) => {
-      dispatch(option, "changed", {}, { bubbles: true })
-    })
-  },
+  (option) => {}
 )
 
 // Define nested elements first

--- a/src/js/multiselect.js
+++ b/src/js/multiselect.js
@@ -1,0 +1,70 @@
+//@deno-types=./19.ts
+import { $, $$, halts, hotkey, makelogger, mixin, off, on } from "./19.js"
+
+const ilog = makelogger("multiselect")
+
+// TODO: Should this extend FocusGroupMixin?
+export const MultiSelectMixin = mixin(
+  { observedAttributes: ["aria-multiselectable"] },
+  (multiselect) => {
+
+    const sMember = ":state(selectable)"
+    const sSelected = "[aria-selected=true]"
+    let anchor = $$(multiselect, sSelected).at(-1) || $$(multiselect, sMember).at(0)
+
+    const toggle = (member) => {
+      member.ariaSelected = (member.ariaSelected === "true") ? null : "true"
+      if (member.ariaSelected)
+        anchor = member
+    }
+
+    const hotkeys = hotkey({
+      " ": halts("default", (e) => {
+        toggle(e.target)
+      }),
+      "Shift+ArrowDown": halts("default", (e) => {
+        toggle(document.activeElement)
+      }),
+      "Shift+ArrowUp": halts("default", (e) => {
+        toggle(document.activeElement)
+      }),
+      "Shift+ ": halts("default", (e) => {
+        const members = $$(multiselect, sMember)
+        const start = members.indexOf(anchor)
+        const end = members.indexOf(document.activeElement)
+        members.slice(
+          Math.min(start, end),
+          Math.max(start, end) + 1,
+        ).forEach(m => m.ariaSelected = "true")
+        anchor = members.at(end)
+      }),
+      "Ctrl+Shift+Home": halts("default", (e) => {
+        const members = $$(multiselect, sMember)
+        const start = members.indexOf(document.activeElement)
+        members.slice(0, start).forEach(m => m.ariaSelected = "true")
+        anchor = members.at(0)
+      }),
+      "Ctrl+Shift+End": halts("default", (e) => {
+        const members = $$(multiselect, sMember)
+        const start = members.indexOf(document.activeElement)
+        members.slice(start).forEach(m => m.ariaSelected = "true")
+        anchor = members.at(-1)
+      }),
+      "Ctrl+A": halts("default", (e) => {
+        const members = $$(multiselect, sMember)
+        const all = members.every(m => m.ariaSelected === "true")
+        members.forEach(m => m.ariaSelected = all ? null : "true")
+        anchor = (all) ? members.at(0) : members.at(-1)
+      }),
+    })
+
+    let keys, click
+    on(multiselect, "attribute:aria-multiselectable", (e) => {
+      if (e.detail.value === "true") {
+        keys = on(multiselect, "keydown", hotkeys)
+        click = on(multiselect, "click", (e) => toggle(e.target))
+      } else if (keys || click)
+        off(keys), off(click)
+    })
+  }
+)

--- a/src/js/mutation.js
+++ b/src/js/mutation.js
@@ -1,10 +1,12 @@
 //@deno-types=./19.ts
-import { dispatch, mixin, on } from "./19.js"
+import { dispatch, makelogger, mixin, on } from "./19.js"
+
+const ilog = makelogger("mutation")
 
 export const MutationMixin = (mutationOptions) => mixin((el) => {
-  on(el, "connect", (e) => {
+  on(el, "connected", (e) => {
     el.observer = new MutationObserver((records, observer) =>
-      records.forEach(r => dispatch(this, `mutation:${r.type}`, r)))
+      records.forEach(r => dispatch(el, `mutation:${r.type}`, r)))
     el.observer.observe(el, mutationOptions)
   })
 

--- a/src/js/mutation.js
+++ b/src/js/mutation.js
@@ -1,0 +1,13 @@
+//@deno-types=./19.ts
+import { dispatch, mixin, on } from "./19.js"
+
+export const MutationMixin = (mutationOptions) => mixin((el) => {
+  on(el, "connect", (e) => {
+    el.observer = new MutationObserver((records, observer) =>
+      records.forEach(r => dispatch(this, `mutation:${r.type}`, r)))
+    el.observer.observe(el, mutationOptions)
+  })
+
+  on(el, "disconnected", (e) =>
+    el.observer?.disconnect())
+})

--- a/src/js/selectable.js
+++ b/src/js/selectable.js
@@ -1,14 +1,30 @@
 //@deno-types=./19.ts
-import { $, $$, halt, makelogger, mixin, on } from "./19.js"
+import { makelogger, mixin, on } from "./19.js"
 
 const ilog = makelogger("selectable")
+
+const roles = /** @type {const} */ ([
+  "gridcell",
+  "option",
+  "row",
+  "tab",
+  "columnheader",
+  "rowheader",
+  "treeitem",
+])
+
 
 export const SelectableMixin = mixin(
   {
     internals: { ariaSelected: "false" },
-    observedAttributes: ["tabindex"],
+    observedAttributes: ["tabindex", "aria-selected"],
   },
   (el) => {
+
+    const role = () => (el.internals || el).role
+
+    if (!roles.includes(role()))
+      return console.error(el, `role must be one of ${roles}; got ${role()}.`)
 
     el.internals.states.add("selectable")
 
@@ -22,6 +38,10 @@ export const SelectableMixin = mixin(
       if (container && container.ariaMultiSelectable !== "true") {
         el.ariaSelected = (e.detail.value == "0") ? "true" : null
       }
+    })
+
+    on(el, "attribute:aria-selected", (e) => {
+      dispatch(el, "changed", {}, { bubbles: true })
     })
   }
 )

--- a/src/js/selectable.js
+++ b/src/js/selectable.js
@@ -1,0 +1,27 @@
+//@deno-types=./19.ts
+import { $, $$, halt, makelogger, mixin, on } from "./19.js"
+
+const ilog = makelogger("selectable")
+
+export const SelectableMixin = mixin(
+  {
+    internals: { ariaSelected: "false" },
+    observedAttributes: ["tabindex"],
+  },
+  (el) => {
+
+    el.internals.states.add("selectable")
+
+    on(el, "connected", (e) => {
+      const isSelected = (el.ariaSelected || el.hasAttribute("selected"))
+      el.tabIndex = (isSelected) ? 0 : -1
+    })
+
+    on(el, "attribute:tabindex", (e) => {
+      const container = el.closest(":state(focusgroup)")
+      if (container && container.ariaMultiSelectable !== "true") {
+        el.ariaSelected = (e.detail.value == "0") ? "true" : null
+      }
+    })
+  }
+)

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -6,8 +6,9 @@ import { focusGroup } from "./focusgroup.js";
 
 const ilog = makelogger("tabs");
 
-const tablist = tag("aria-tablist", { base: focusGroup }, (tablist) => {
+const tablist = tag("aria-tablist", (tablist) => {
   tablist.internals.role = "tablist"
+  focusGroup.install(tablist)
 
   if (!tablist.hasAttribute("aria-labelledby") && !tablist.hasAttribute("aria-label"))
     ilog("ERROR:", tablist, "has no accessible name (aria-label or aria-labelledby)")

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,29 +1,44 @@
-/// a tabs library.
-
 //@deno-types=./19.ts
-import { on, attr, makelogger, tag } from "./19.js"
-import { focusGroup } from "./focusgroup.js"
+import { $$, css, makelogger, on, tag } from "./19.js"
+import { validate } from "./validate.js"
+import { FocusGroupMixin } from "./focusgroup.js"
+import { SelectableMixin } from "./selectable.js"
+import { MultiSelectMixin } from "./multiselect.js"
 
 const ilog = makelogger("tabs")
 
-const tablist = tag(
+export const tablist = tag(
   "aria-tablist",
-  { internals: { role: "tablist" } },
-  (tablist) => { focusGroup.install(tablist) }
+  {
+    internals: { role: "tablist", ariaMultiSelectable: "false" },
+    mixins: [
+      FocusGroupMixin,
+      MultiSelectMixin,
+      validate({ label: true, sChildren: "aria-tab" }),
+    ],
+  },
+  (tablist) => {
+    on(tablist, "attribute:aria-multiselectable", (e) => {
+      if (e.detail.value === "true")
+        $$(tablist, "aria-tab").forEach(tab => {
+          tab.internals.ariaExpanded = false
+          tab.ariaExpanded = (tab.ariaSelected === "true") ? "true" : null
+        })
+    })
+  }
 )
 
-const tab = tag(
+export const tab = tag(
   "aria-tab",
   {
-    internals: { role: "tab", ariaSelected: "false" },
-    observedAttributes: ["aria-controls", "tabindex", "aria-selected"],
+    internals: { role: "tab" },
+    mixins: [
+      SelectableMixin,
+      validate({ sParent: "aria-tablist" }),
+    ],
+    observedAttributes: ["aria-controls", "aria-selected"],
   },
   (tab) => {
-
-    tab.tabIndex = (tab.ariaSelected == "true") ? "0" : "-1"
-
-    tab.open  = () => { attr(tab, "aria-selected", "true") }
-    tab.close = () => { attr(tab, "aria-selected",  null ) }
 
     on(tab, "attribute:aria-controls", (e) => {
       if ("ariaControlsElements" in tab)
@@ -34,28 +49,30 @@ const tab = tag(
       if (tab.panel)
         tab.panel.hidden = (tab.ariaSelected !== "true")
       else
-        return ilog("ERROR:", tab, "has no associated tabpanel")
+        return console.error(tab, "has no associated <aria-tabpanel>")
 
       if ("ariaLabelledByElements" in tab.internals)
         tab.panel.internals.ariaLabelledByElements = [tab]
       else
-        attr(tab.panel, "aria-labelledby", identify(tab))
+        tab.panel.setAttribute("aria-labelledby", identify(tab))
     })
-
-    on(tab, "attribute:tabindex", (e) =>
-      tab.ariaSelected = (e.detail.value == "0") ? "true" : null)
 
     on(tab, "attribute:aria-selected", (e) => {
-      if (tab.panel)
+      if (tab.panel) {
         tab.panel.hidden = (e.detail.value !== "true")
+        if (tab.parentElement.ariaMultiSelectable === "true")
+          tab.ariaExpanded = (tab.panel.hidden) ? null : "true"
+      }
     })
-
   }
 )
 
-const tabpanel = tag(
+export const tabpanel = tag(
   "aria-tabpanel",
-  { internals: { role: "tabpanel" } },
+  {
+    internals: { role: "tabpanel" },
+    css: css`:host { display: block }`,
+  },
   (tabpanel) => {},
 )
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,48 +1,65 @@
 /// a tabs library.
 
 //@deno-types=./19.ts
-import { $, $$, on, attr, next, prev, asHtml, hotkey, behavior, makelogger, identify, dispatch, tag, html } from "./19.js";
-import { focusGroup } from "./focusgroup.js";
+import { on, attr, makelogger, tag } from "./19.js"
+import { focusGroup } from "./focusgroup.js"
 
-const ilog = makelogger("tabs");
+const ilog = makelogger("tabs")
 
-const tablist = tag("aria-tablist", (tablist) => {
-  tablist.internals.role = "tablist"
-  focusGroup.install(tablist)
+const tablist = tag(
+  "aria-tablist",
+  { internals: { role: "tablist" } },
+  (tablist) => { focusGroup.install(tablist) }
+)
 
-  if (!tablist.hasAttribute("aria-labelledby") && !tablist.hasAttribute("aria-label"))
-    ilog("ERROR:", tablist, "has no accessible name (aria-label or aria-labelledby)")
-})
+const tab = tag(
+  "aria-tab",
+  {
+    internals: { role: "tab", ariaSelected: "false" },
+    observedAttributes: ["aria-controls", "tabindex", "aria-selected"],
+  },
+  (tab) => {
 
-const tab = tag("aria-tab", (tab) => {
-  tab.internals.role = "tab"
-  tab.tabIndex = -1
+    tab.tabIndex = (tab.ariaSelected == "true") ? "0" : "-1"
 
-  if (tab.ariaControlsElements.length === 0)
-    console.error("ERROR:", this, "has no associated tabpanel")
+    tab.open  = () => { attr(tab, "aria-selected", "true") }
+    tab.close = () => { attr(tab, "aria-selected",  null ) }
 
-  const tabpanel = (t = tab) => t.ariaControlsElements[0]
-  const tablist = () => tab.closest("aria-tablist")
-  const siblings = () => tablist().querySelectorAll("aria-tab")
+    on(tab, "attribute:aria-controls", (e) => {
+      if ("ariaControlsElements" in tab)
+        tab.panel = tab.ariaControlsElements[0]
+      else
+        tab.panel = tab.getRootNode().getElementById(e.detail.value)
 
-  const close = (tab) => {
-    tab.ariaSelected = false
-    tabpanel(tab).hidden = true
+      if (tab.panel)
+        tab.panel.hidden = (tab.ariaSelected !== "true")
+      else
+        return ilog("ERROR:", tab, "has no associated tabpanel")
+
+      if ("ariaLabelledByElements" in tab.internals)
+        tab.panel.internals.ariaLabelledByElements = [tab]
+      else
+        attr(tab.panel, "aria-labelledby", identify(tab))
+    })
+
+    on(tab, "attribute:tabindex", (e) =>
+      tab.ariaSelected = (e.detail.value == "0") ? "true" : null)
+
+    on(tab, "attribute:aria-selected", (e) => {
+      if (tab.panel)
+        tab.panel.hidden = (e.detail.value !== "true")
+    })
+
   }
+)
 
-  const open = (focusTab = true) => {
-    siblings().forEach(close)
-    tab.ariaSelected = true
-    tabpanel(tab).hidden = false
-  }
+const tabpanel = tag(
+  "aria-tabpanel",
+  { internals: { role: "tabpanel" } },
+  (tabpanel) => {},
+)
 
-  on(tab, "click", () => open())
-  on(tab, "focus", () => open())
-})
-
-const tabpanel = tag("aria-tabpanel", panel =>
-  panel.internals.role = "tabpanel")
-
-tablist.define()
-tab.define()
+// Define nested elements first
 tabpanel.define()
+tab.define()
+tablist.define()

--- a/src/js/toolbar.js
+++ b/src/js/toolbar.js
@@ -1,0 +1,16 @@
+//@deno-types=./19.ts
+import { tag } from "./19.js"
+import { validate } from "./validate.js"
+import { FocusGroupMixin } from "./focusgroup.js"
+
+// TODO: Support focusability of disabled elements
+export const toolbar = tag(
+  "aria-toolbar",
+  {
+		internals: { role: "toolbar" },
+		mixins: [FocusGroupMixin, validate({ label: true })],
+	},
+  (toolbar) => {}
+)
+
+toolbar.define()

--- a/src/js/typeahead.js
+++ b/src/js/typeahead.js
@@ -1,0 +1,58 @@
+//@deno-types=./19.ts
+import { $$, halt, makelogger, mixin, on } from "./19.js"
+
+const ilog = makelogger("type-ahead")
+
+const TIMEOUT = 500 // WAI-ARIA APG recommendation
+
+// TODO: Not compatible with aria-activedescendent.
+// TODO: Should this extend FocusGroupMixin?
+export const TypeAheadMixin = mixin(
+  (group) => {
+
+    const sMember = "[tabindex]:not(:state(focusgroup))"
+    const current = () => group.contains(document.activeElement)
+      ? document.activeElement
+      : null
+
+    const nameOf = (member) =>
+      (member.ariaLabel || member.textContent.trim() || "").toLowerCase()
+
+    const validKey = (e) =>
+      !(e.altKey || e.ctrlKey || e.metaKey) && e.key.match(/^.$/u)
+
+    let state = { query: "", timeout: null }
+    const reset = () => {
+      clearTimeout(state.timeout)
+      state = { query: "", timeout: null }
+    }
+    const find = (query) => {
+      const members = $$(group, sMember)
+      const start = members.indexOf(document.activeElement)
+      for (let i = 0; i < members.length; i++) {
+        const member = members[(start + i) % members.length]
+        if (nameOf(member).startsWith(query))
+          return member
+      }
+    }
+
+    on(group, "keydown", (e) => {
+      if (current() === null || !validKey(e)) return
+
+      halt("default", e)
+
+      if (state.timeout) {
+        state.query += e.key.toLowerCase()
+        clearTimeout(state.timeout)
+      } else {
+        state.query = e.key
+      }
+      state.timeout = setTimeout(reset, TIMEOUT)
+
+      const found = find(state.query)
+      if (found) found.focus()
+    })
+
+    on(group, "disconnect", (e) => reset())
+  }
+)

--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -1,0 +1,37 @@
+//@deno-types=./19.ts
+import { makelogger, mixin } from "./19.js"
+
+const ilog = makelogger("validate")
+
+/**
+ * Validate author generated markup.
+ * @param {object} [options]
+ * @param {boolean} [options.label] Whether to validate if an accessible label exists.
+ * @param {string} [options.sParent] The selector to validate parentElement against.
+ * @param {string} [options.sChildren] The selector to validate children against.
+ */
+export const validate = (options) => mixin((el) => {
+  const {
+    name = false,
+    sParent = "",
+    sChildren = "",
+  } = options
+
+  // TODO: See ilog() below. At the time validate() is run, Firefox has associated
+  // the label with el.internals, but Chrome hasn't.
+  const validName = () => (
+    (el.hasAttribute("aria-labelledby") || el.hasAttribute("aria-label")) ||
+    (el.constructor.formAssociated && ilog(el.internals.labels)?.length)
+  )
+  const validParent = () => el.matches(`${sParent} > *`)
+  const validChildren = () => el.matches(`:not(:has(> :not(${sChildren})))`)
+
+  if (name && !validName())
+    console.warn(el, "has no accessible name (aria-label or aria-labelledby).")
+
+  if (sParent && !validParent())
+    console.error(el, `must be contained in an element matching the selector "${sParent}".`)
+
+  if (sChildren && !validChildren())
+    return console.error(el, `can only contain elements matching the selector "${sChildren}".`)
+})

--- a/src/main.css
+++ b/src/main.css
@@ -1037,6 +1037,6 @@ dialog:is([open], [popover])::backdrop {
 }
 
 dialog:not([popover], [open]),
-[popover]:not(:popover-over) {
+[popover]:not(:popover-open) {
     display: none;
 }

--- a/www/demos/apg/feed.md
+++ b/www/demos/apg/feed.md
@@ -29,8 +29,14 @@ Missing.css provides the `<aria-feed>`{ .language-html } custom element for feed
 
  - The author is responsible for loading new content based on user interaction.
    Be sure to set `<aria-feed aria-busy=true>`{ .language-html } during this process.
+   After your feed is updated, be sure to remove the attribute.
 
- - The `<aria-feed>`{ .language-html } element uses MutationObserver to update ARIA attributes on `<article>`{ .language-html } or `[role=article]`{ .token .attr-name } elements when new content is appended.
+ - The `<aria-feed>`{ .language-html } element uses MutationObserver to update the following attributes on `<article>`{ .language-html } or `[role=article]`{ .token .attr-name } elements when new content is appended:
+    - `tabindex`{ .token .attr-name },
+    - `aria-posinset`{ .token .attr-name }, and
+    - `aria-setsize`{ .token .attr-name }.
+
+   It will also validate that the articles contain `aria-labelledby`{ .token .attr-name } and `aria-describedby`{ .token .attr-name } attributes.
 
  - If the total number of `<article>`{ .language-html } elements is extremely large, indefinite, or changes often, authors may use the `<aria-feed infinite>`{ .language-html } attribute, which sets `<article aria-setsize="-1">`{ .language-html } on child elements in order to communicate the unknown size of the set to assistive technologies.
 
@@ -56,12 +62,14 @@ This example requires JavaScript to be activated.
 	$$(feed, "article").forEach(label)
 	let count = feed.children.length
 	on($(document, "button"), "click", (e) => {
+		feed.ariaBusy = "true"
 		count++
 		const article = $(document, "template").content.cloneNode(true).firstElementChild
 		$(article, "h4").textContent = `Blog Post ${count}`
 		label(article)
 		$$(article, "article").forEach(label)
 		feed.appendChild(article)
+		feed.ariaBusy = null
 	})
 </script>
 

--- a/www/demos/apg/feed.md
+++ b/www/demos/apg/feed.md
@@ -20,16 +20,19 @@ shortcuts:
    text: Move focus to the first article in nested feed.
  - keys: ["Alt", "PageUp"]
    text: Move focus from a nested feed to the parent article.
-useTag: false
 ---
 
 
 ## Notes
 
-<!-- Missing.css provides the `<aria-feed>`{ .language-html } custom element for feeds.-->
-Missing.css uses the `<section role=feed>`{ .language-html } element to define feeds.
-To get the actual behavior of an accessible feed, you can use [Missing.js &sect; Feed](/docs/js#feed).
+Missing.css provides the `<aria-feed>`{ .language-html } custom element for feeds.
 
+ - The author is responsible for loading new content based on user interaction.
+   Be sure to set `<aria-feed aria-busy=true>`{ .language-html } during this process.
+
+ - The `<aria-feed>`{ .language-html } element uses MutationObserver to update ARIA attributes on `<article>`{ .language-html } or `[role=article]`{ .token .attr-name } elements when new content is appended.
+
+ - If the total number of `<article>`{ .language-html } elements is extremely large, indefinite, or changes often, authors may use the `<aria-feed infinite>`{ .language-html } attribute, which sets `<article aria-setsize="-1">`{ .language-html } on child elements in order to communicate the unknown size of the set to assistive technologies.
 
 {{ include "demo_kbd.vto" }}
 
@@ -42,21 +45,33 @@ This example requires JavaScript to be activated.
 
 </noscript>
 <script type=module>
-	import { attr, identify } from "/dist/js/19.js"
-	document.querySelectorAll("article").forEach(article => {
-		attr(article, 'aria-labelledby', identify(article.firstElementChild))
+	import { $, $$, attr, identify, on } from "/dist/js/19.js"
+	function label(article) {
+		attr(article, {
+			'aria-labelledby': identify(article.firstElementChild),
+			'aria-describedby': identify($(article, 'p')),
+		})
+	}
+	const feed = $(document, "aria-feed")
+	$$(feed, "article").forEach(label)
+	let count = feed.children.length
+	on($(document, "button"), "click", (e) => {
+		count++
+		const article = $(document, "template").content.cloneNode(true).firstElementChild
+		$(article, "h4").textContent = `Blog Post ${count}`
+		label(article)
+		$$(article, "article").forEach(label)
+		feed.appendChild(article)
 	})
 </script>
 
 <figure>
-	<h3 id=feed-label>Blog Post Feed and with Nested Comment Feeds</h3>
-	<a href=#>A focusable element before the feed</a>
-	<section role=feed aria-labelledby=feed-label>
+	<template>
 		<article class="crowded box">
 			<h4>Blog Post 1</h4>
 			<p>Some content for the blog post.</p>
 			<a href=#>Read more...</a>
-			<section role=feed>
+			<aria-feed aria-label="Comment Feed 1">
 				<article class="box ok">
 					<h5 class="titlebar">Comment #1</h5>
 					<p>Some content for the comment.</p>
@@ -72,13 +87,40 @@ This example requires JavaScript to be activated.
 					<p>Some content for the comment.</p>
 					<a href=#>Edit</a> <a href=#>Delete</a>
 				</article>
-			</section role=feed>
+			</aria-feed>
+		</article>
+	</template>
+	<h3 id=feed-label>Blog Post Feed and with Nested Comment Feeds</h3>
+	<button id="load-article">Load an article</button>
+	<p><a href=#>A focusable element before the feed</a></p>
+	<aria-feed aria-labelledby=feed-label>
+		<article class="crowded box">
+			<h4>Blog Post 1</h4>
+			<p>Some content for the blog post.</p>
+			<a href=#>Read more...</a>
+			<aria-feed aria-label="Comment Feed 1">
+				<article class="box ok">
+					<h5 class="titlebar">Comment #1</h5>
+					<p>Some content for the comment.</p>
+					<a href=#>Edit</a> <a href=#>Delete</a>
+				</article>
+				<article class="box ok">
+					<h5 class="titlebar">Comment #2</h5>
+					<p>Some content for the comment.</p>
+					<a href=#>Edit</a> <a href=#>Delete</a>
+				</article>
+				<article class="box ok">
+					<h5 class="titlebar">Comment #3</h5>
+					<p>Some content for the comment.</p>
+					<a href=#>Edit</a> <a href=#>Delete</a>
+				</article>
+			</aria-feed>
 		</article>
 		<article class="crowded box">
 			<h4>Blog Post 2</h4>
 			<p>Some content for the blog post.</p>
 			<a href=#>Read more...</a>
-			<section role=feed>
+			<aria-feed aria-label="Comment Feed 2">
 				<article class="box ok">
 					<h5 class="titlebar">Comment #1</h5>
 					<p>Some content for the comment.</p>
@@ -94,13 +136,13 @@ This example requires JavaScript to be activated.
 					<p>Some content for the comment.</p>
 					<a href=#>Edit</a> <a href=#>Delete</a>
 				</article>
-			</section role=feed>
+			</aria-feed>
 		</article>
 		<article class="crowded box">
 			<h4>Blog Post 3</h4>
 			<p>Some content for the blog post.</p>
 			<a href=#>Read more...</a>
-			<section role=feed>
+			<aria-feed aria-label="Comment Feed 3">
 				<article class="box ok">
 					<h5 class="titlebar">Comment #1</h5>
 					<p>Some content for the comment.</p>
@@ -116,10 +158,10 @@ This example requires JavaScript to be activated.
 					<p>Some content for the comment.</p>
 					<a href=#>Edit</a> <a href=#>Delete</a>
 				</article>
-			</section role=feed>
+			</aria-feed>
 		</article>
-	</section role=feed>
-	<a href=#>A focusable element after the second feed</a>
+	</aria-feed>
+	<p><a href=#>A focusable element after the second feed</a></p>
 </figure>
 
 <script type=module src=/dist/js/feed.js></script>

--- a/www/demos/apg/listbox.md
+++ b/www/demos/apg/listbox.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 title: Listbox
 templateEngine: [vento, md]
 apg:
@@ -21,8 +20,22 @@ shortcuts:
 
 ## Notes
 
-Missing.css provides the `<aria-listbox>`{ .language-html } custom element for listboxes.
+Missing.css provides the following custom elements for listboxes:
 
+- `<aria-listbox>`{ .language-html }
+- `<aria-optgroup>`{ .language-html }
+- `<aria-option>`{ .language-html }
+
+`<aria-listbox>`{ .language-html } is a [Form Associated Custom Element][face] and can be used with or without a `<form>`{ .language-html }.
+
+Similar to the [`selected`{ .token .attr-name } HTML attribute][selected] for `<option>`{ .language-html } elements,
+default state can be specified using `<aria-option selected>`{ .language-html }.
+To actually set the selected state of an `<aria-option>`{ .language-html }, the `[aria-selected=true]`{ .token .attr-name } HTML attribute should be used.
+When a listbox contains both elements with `[selected]`{ .token .attr-name } and elements with `[aria-selected=true]`{ .token .attr-name }, the latter ones will take precedence in order to preserve state when a live DOM tree is stringified and restored.
+This can be observed by clicking the "reset" button below.
+
+[face]: https://html.spec.whatwg.org/dev/custom-elements.html#form-associated-custom-element
+[selected]: https://html.spec.whatwg.org/multipage/form-elements.html#attr-option-selected
 
 {{ include "demo_kbd.vto" }}
 
@@ -37,42 +50,83 @@ This example requires JavaScript to be activated.
 
 <figure>
 	<style>
-		[role=listbox] {
-			max-height: 200px;
-			overflow: auto;
+		aria-listbox.box {
+			padding-block: 0;
+			margin-block-start: 0;
+			/*overflow: auto;
+			max-height: 300px;*/
 		}
 	</style>
-	<strong>ARIA Patterns</strong>
-	<ul role=listbox class="crowded box with flow-gap">
-		<li role=option>Accordion
-		<li role=option>Alert
-		<li role=option>Alert and Message Dialogs
-		<li role=option>Breadcrumb
-		<li role=option>Button
-		<li role=option>Carousel
-		<li role=option>Checkbox
-		<li role=option>Combobox
-		<li role=option>Dialog (Modal)
-		<li role=option>Disclosure
-		<li role=option>Feed
-		<li role=option>Grid
-		<li role=option>Landmarks
-		<li role=option>Link
-		<li role=option aria-selected=true>Listbox
-		<li role=option>Menu and Menubar
-		<li role=option>Menu Button
-		<li role=option>Meter
-		<li role=option>Radio Group
-		<li role=option>Slider
-		<li role=option>Slider (Multi-Thumb)
-		<li role=option>Spinbutton
-		<li role=option>Switch
-		<li role=option>Table
-		<li role=option>Tabs
-		<li role=option>Toolbar
-		<li role=option>Tooltip
-		<li role=option>Tree View
-		<li role=option>Treegrid
-		<li role=option>Window Splitter
-	</ul>
+	<script>
+		function logFormData() {
+			event.preventDefault()
+            const data = new FormData(event.target)
+			console.log([...data.entries()])
+			alert('Form data has been logged to console.')
+		}
+	</script>
+    <p class="bad box">
+      <strong>NOTE:</strong> On Firefox, <code>aria-listbox { overflow: auto; max-height: 300px }</code> must be disabled.
+      More information is avaiable at <a href="https://codepen.io/dr_ironbeard/pen/pvgOzrG">this CodePen</a>.
+    </p>
+	<form onsubmit="logFormData()">
+	<label for=single-listbox>ARIA APG Patterns</label>
+	<aria-listbox id=single-listbox name=single class="box">
+		<aria-option value=accordion>Accordion</aria-option>
+		<aria-option value=alert>Alert</aria-option>
+		<aria-option value=alertdialog aria-selected=true>Alert and Message Dialogs</aria-option>
+		<aria-option value=breadcrumb>Breadcrumb</aria-option>
+		<aria-option value=button>Button</aria-option>
+		<aria-option value=carousel>Carousel</aria-option>
+		<aria-option value=checkbox>Checkbox</aria-option>
+		<aria-option value=combobox>Combobox</aria-option>
+		<aria-option value=dialog>Dialog (Modal)</aria-option>
+		<aria-option value=disclosure>Disclosure</aria-option>
+		<aria-option value=feed>Feed</aria-option>
+		<aria-option value=grid>Grid</aria-option>
+		<aria-option value=landmarks>Landmarks</aria-option>
+		<aria-option value=link>Link</aria-option>
+		<aria-option value=listbox selected>Listbox</aria-option>
+		<aria-option value=menubar>Menu and Menubar</aria-option>
+		<aria-option value=menubutton>Menu Button</aria-option>
+		<aria-option value=meter>Meter</aria-option>
+		<aria-option value=radio>Radio Group</aria-option>
+		<aria-option value=slider>Slider</aria-option>
+		<aria-option value=slider-multi>Slider (Multi-Thumb)</aria-option>
+		<aria-option value=spinbutton>Spinbutton</aria-option>
+		<aria-option value=switch>Switch</aria-option>
+		<aria-option value=table>Table</aria-option>
+		<aria-option value=tabs>Tabs</aria-option>
+		<aria-option value=toolbar>Toolbar</aria-option>
+		<aria-option value=tooltip>Tooltip</aria-option>
+		<aria-option value=treeview>Tree View</aria-option>
+		<aria-option value=treegrid>Treegrid</aria-option>
+		<aria-option value=window-splitter>Window Splitter</aria-option>
+	</aria-listbox>
+	<label for=multi-listbox>Multiple Select Listbox</label>
+	<aria-listbox id=multi-listbox name=multi aria-multiselectable=true class="box">
+		<aria-optgroup label="Programming Languages">
+			<aria-option value=javascript>JavaScript</aria-option>
+			<aria-option value=typescript selected>TypeScript</aria-option>
+			<aria-option value=python>Python</aria-option>
+			<aria-option value=java>Java</aria-option>
+			<aria-option value=go selected>Go</aria-option>
+			<aria-option value=rust aria-selected=true>Rust</aria-option>
+		</aria-optgroup>
+		<aria-optgroup label="Bagels">
+			<aria-option value=plain>Plain</aria-option>
+			<aria-option value=everything>Everything</aria-option>
+			<aria-option value=blueberry selected>Blueberry</aria-option>
+			<aria-option value=cinnamon-raisin>Cinnamon Raisin</aria-option>
+			<aria-option value=sesame aria-selected=true>Sesame</aria-option>
+			<aria-option value=asiago>Asiago</aria-option>
+		</aria-optgroup>
+	</aria-listbox>
+	<div class="flex-row">
+		<button type=reset>Reset</button>
+		<button type=submit>Submit</button>
+	</div>
+	</form>
 </figure>
+
+<script type=module src=/dist/js/listbox.js></script>

--- a/www/demos/apg/tabs.md
+++ b/www/demos/apg/tabs.md
@@ -25,7 +25,12 @@ shortcuts:
 
 ## Notes
 
-Missing.css provides the `<aria-tablist>`{ .language-html }, `<aria-tab>`{ .language-html }, and `<aria-tabpanel>`{ .language-html } custom elements for tabs.
+Missing.css provides the following custom elements for tabs:
+
+- `<aria-tablist>`{ .language-html }
+- `<aria-tab>`{ .language-html }
+- `<aria-tabpanel>`{ .language-html }
+
 See [Missing.js &sect; Tabs](/docs/js#tabs).
 
  - Don't forget to set an accessible label for the `<aria-tablist>`{ .language-html }.
@@ -50,15 +55,35 @@ This example requires JavaScript to be activated.
 
 <figure>
 	<a href=#>A focusable element before the tabs</a></p>
+    <p>A horizontal tablist.</p>
 	<aria-tablist aria-label="Example">
 		<aria-tab aria-controls=panel-1>Tab 1</aria-tab>
-		<aria-tab aria-controls=panel-2>Tab 2</aria-tab>
+		<aria-tab aria-controls=panel-2 selected>Tab 2</aria-tab>
 		<aria-tab aria-controls=panel-3>Tab 3</aria-tab>
 	</aria-tablist>
 	<aria-tabpanel id=panel-1>This is the content for the first tab.</p></aria-tabpanel>
 	<aria-tabpanel id=panel-2>This is the content for the second tab.</p></aria-tabpanel>
 	<aria-tabpanel id=panel-3>This is the content for the third tab.</p></aria-tabpanel>
+	<a href=#>A focusable element between the tabs</a></p>
+    <p>A vertical tablist.</p>
+	<aria-tablist aria-label="Example" aria-orientation="vertical">
+		<aria-tab aria-controls=panel-4 selected>Tab 1</aria-tab>
+		<aria-tab aria-controls=panel-5>Tab 2</aria-tab>
+		<aria-tab aria-controls=panel-6>Tab 3</aria-tab>
+	</aria-tablist>
+	<aria-tabpanel id=panel-4>The first tab for the vertical tablist.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-5>The second tab for the vertical tablist.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-6>The third tab for the vertical tablist.</p></aria-tabpanel>
 	<a href=#>A focusable element after the tabs</a></p>
+    <p>A multi-selectable tablist.</p>
+	<aria-tablist aria-label="Example" aria-multiselectable="true">
+		<aria-tab aria-controls=panel-7>Tab 1</aria-tab>
+		<aria-tab aria-controls=panel-8 selected>Tab 2</aria-tab>
+		<aria-tab aria-controls=panel-9 selected>Tab 3</aria-tab>
+	</aria-tablist>
+	<aria-tabpanel id=panel-7>This is the content for the first tab.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-8>This is the content for the second tab.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-9>This is the content for the third tab.</p></aria-tabpanel>
 </figure>
 
 <script type=module src=/dist/js/tabs.js></script>

--- a/www/demos/apg/tabs.md
+++ b/www/demos/apg/tabs.md
@@ -25,22 +25,17 @@ shortcuts:
 
 ## Notes
 
-Missing.css uses `<div role=tablist>`{ .language-html }, `<button role=tab>`{ .language-html }, and `<div role=tabpanel>`{ .language-html } for tabs.
-To get the actual behavior of an accessible tabset, you can use [Missing.js &sect; Tabs](/docs/js#tabs).
-
- - Don't forget to set an accessible label for the tablist.
- - You must establish the relationship between `<button role=tab>`{ .language-html } and `<div role=tabpanel>`{ .language-html } elements by including `aria-controls`{ .token .attr-name } attributes on each `<button role=tab>`{ .language-html }.
-   The JavaScript behavior will set the reverse `aria-labelledby`{ .token .attr-name } attributes (generating unique ids if necessary).
- - You must set the initial state with `<button role=tab aria-selected=true>`{ .language-html } and `<div role=tabpanel hidden>`{ .language-html }).
-
-<!--
 Missing.css provides the `<aria-tablist>`{ .language-html }, `<aria-tab>`{ .language-html }, and `<aria-tabpanel>`{ .language-html } custom elements for tabs.
+See [Missing.js &sect; Tabs](/docs/js#tabs).
 
  - Don't forget to set an accessible label for the `<aria-tablist>`{ .language-html }.
+
  - You must establish the relationship between `<aria-tab>`{ .language-html } and `<aria-tabpanel>`{ .language-html } elements by providing `aria-controls`{ .token .attr-name } attributes to each `<aria-tab>`{ .language-html }.
-		The component will set the reverse `aria-labelledby`{ .token .attr-name } attributes (generating unique ids if necessary).
- - You must set the initial state with `<aria-tab aria-selected=true>`{ .language-html } and `<aria-tabpanel hidden>`{ .language-html }).
--->
+   The component will set the reverse `aria-labelledby`{ .token .attr-name } attributes (generating unique ids if necessary).
+
+ - It is highly recommended you set the initial state with `<aria-tab aria-selected=true>`{ .language-html } and `<aria-tabpanel hidden>`{ .language-html }.
+   If initial state is not provided, the custom element will select the first tab, likely resulting in a DOM reflow as the remaining `<aria-tabpanel>`{ .language-html } instances are hidden.
+
 
 {{ include "demo_kbd.vto" }}
 
@@ -55,26 +50,14 @@ This example requires JavaScript to be activated.
 
 <figure>
 	<a href=#>A focusable element before the tabs</a></p>
-	<div>
-		<div role=tablist>
-			<button role=tab id=tab-1 aria-controls=panel-1 aria-selected=true>Tab 1</button>
-			<button role=tab id=tab-2 aria-controls=panel-2>Tab 2</button>
-			<button role=tab id=tab-3 aria-controls=panel-3>Tab 3</button>
-		</div>
-		<div role=tabpanel id=panel-1 aria-labelledby=tab-1><p>This is the content for the first tab</div>
-		<div role=tabpanel id=panel-2 aria-labelledby=tab-2 hidden><p>This is the content for the second tab</div>
-		<div role=tabpanel id=panel-3 aria-labelledby=tab-3 hidden><p>This is the content for the third tab</div>
-	</div>
-	<!--
 	<aria-tablist aria-label="Example">
-		<aria-tab aria-controls=panel-1                   >Tab 1</aria-tab>
-		<aria-tab aria-controls=panel-2 aria-selected=true>Tab 2</aria-tab>
-		<aria-tab aria-controls=panel-3                   >Tab 3</aria-tab>
+		<aria-tab aria-controls=panel-1>Tab 1</aria-tab>
+		<aria-tab aria-controls=panel-2>Tab 2</aria-tab>
+		<aria-tab aria-controls=panel-3>Tab 3</aria-tab>
 	</aria-tablist>
-	<aria-tabpanel id=panel-1 hidden>This is the content for the first tab.</p></aria-tabpanel>
-	<aria-tabpanel id=panel-2       >This is the content for the second tab.</p></aria-tabpanel>
-	<aria-tabpanel id=panel-3 hidden>This is the content for the third tab.</p></aria-tabpanel>
-	-->
+	<aria-tabpanel id=panel-1>This is the content for the first tab.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-2>This is the content for the second tab.</p></aria-tabpanel>
+	<aria-tabpanel id=panel-3>This is the content for the third tab.</p></aria-tabpanel>
 	<a href=#>A focusable element after the tabs</a></p>
 </figure>
 

--- a/www/demos/apg/toolbar.md
+++ b/www/demos/apg/toolbar.md
@@ -1,5 +1,4 @@
 ---
-draft: true
 title: Toolbar
 templateEngine: [vento, md]
 apg:
@@ -15,9 +14,9 @@ shortcuts:
  - keys: ["Shift", "Tab"]
    text: Tab in and out of the toolbar, remembering previous focus.
  - keys: ["Left Arrow"]
-   text: Move focus to the previous item.
+   text: Move focus to the previous item (dependent on writing mode / direction).
  - keys: ["Right Arrow"]
-   text: Move focus to the next item.
+   text: Move focus to the next item (dependent on writing mode / direction).
  - keys: ["Home"]
    text: Move focus to the first item.
  - keys: ["End"]
@@ -33,6 +32,8 @@ shortcuts:
 
 Missing.css provides the `<aria-toolbar>`{ .language-html } custom element for toolbars.
 
+Arrow key navigation of toolbar items takes into account the `dir`{ .token .attr-name } HTML attribute and `writing-mode`{ .token .attr-name } CSS property.
+
 
 {{ include "demo_kbd.vto" }}
 
@@ -45,16 +46,124 @@ This example requires JavaScript to be activated.
 
 </noscript>
 
-<figure>
-	<div class="container flex-column">
-		<a href=#>Focusable element before the toolbar</a>
-		<section class="tool-bar">
-			<button type=button>Cut</button>
-			<button type=button>Copy</button>
-			<button type=button>Paste</button>
+<div style="writing-mode: horizontal-tb">
+	<figure dir=ltr>
+		<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>horizontal-tb, ltr</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
 			<hr aria-orientation=vertical>
-			<label>Find: <input type=text></label>
-		</section>
-		<a href=#>Focusable element after the toolbar</a>
-	</div>
-</figure>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+	
+	<figure dir=rtl>
+		<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>horizontal-tb, rtl</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+			<hr aria-orientation=vertical>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+</div>
+<div style="writing-mode: vertical-lr">
+	<figure dir=ltr>
+		<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>vertical-rl, ltr</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+			<hr aria-orientation=vertical>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+</div>
+<div style="writing-mode: vertical-lr">
+	<figure dir=rtl>
+	<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>vertical-rl, rtl</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+			<hr aria-orientation=vertical>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+</div>
+<div style="writing-mode: vertical-rl">
+	<figure dir=ltr>
+		<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>vertical-rl, ltr</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+			<hr aria-orientation=vertical>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+</div>
+<div style="writing-mode: vertical-rl">
+	<figure dir=rtl>
+		<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>vertical-rl, rtl</figcaption>
+		<p><a href=#>Focusable element before the toolbar</a></p>
+		<aria-toolbar class="tool-bar">
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+			<hr aria-orientation=vertical>
+			<label>Find: <input type=text tabindex=-1></label>
+		</aria-toolbar>
+		<p><a href=#>Focusable element between the toolbars</a></p>
+		<aria-toolbar class="tool-bar" aria-orientation=vertical>
+			<button type=button tabindex=-1>Cut</button>
+			<button type=button tabindex=-1>Copy</button>
+			<button type=button tabindex=-1>Paste</button>
+		</aria-toolbar>
+		<p><a href=#>Focusable element after the toolbar</a></p>
+	</figure>
+</div>
+
+<script type=module src=/dist/js/toolbar.js></script>

--- a/www/demos/js/commandbutton.md
+++ b/www/demos/js/commandbutton.md
@@ -1,0 +1,97 @@
+---
+title: Command Button
+templateEngine: [vento, md]
+shortcuts:
+ - keys: ["Enter"]
+   text: Trigger the command on the specified element.
+ - keys: ["Space"]
+   text: Trigger the command on the specified element.
+---
+
+
+## Notes
+
+Missing.js provides a behavior polyfill for the [Invoker Commands API][invoker-api-mdn].
+
+Pressing a `<button command=--foo commandfor=id>`{ .language-html } will trigger a (polyfilled) [`CommandEvent`][whatwg-commandevent] on the element whose id matches the `commandfor`{ .token .attr-name } attribute.
+The `command`{ .token .attr-name } attribute is an [enumerated attribute][whatwg-command]:
+
+| Value              | Method                     |
+|--------------------|----------------------------|
+| `toggle-popover`   | `.togglePopover()`         |
+| `show-popover`     | `.showPopover()`           |
+| `hide-popover`     | `.hidePopover()`           |
+| `close`            | `.close()`                 |
+| `request-close`    | `.requestClose()`          |
+| `show-modal`       | `.showModal()`             |
+| `--custom-command` | Must be prefixed with `--` |
+
+{ .width:100% }
+
+If the `command`{ .token .attr-name } value corresponds with an enumerated method, then the method will be called on the target.
+The `CommandEvent`{ .language-js } will be fired regardless.
+
+If `commandfor`{ .token .attr-name } references an element with the `popover`{ .token .attr-name } attribute,
+the polyfill will correctly set `aria-expands`{ .token .attr-name } and `aria-details`{ .token .attr-name } as
+outlined in the [HTML Accessibility API Mappings][html-aria-mapping].
+
+TODO: Discuss re-initialization of dynamic content.
+
+[invoker-api-mdn]: https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API
+[whatwg-commandevent]: https://html.spec.whatwg.org/multipage/interaction.html#commandevent
+[whatwg-command]: https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
+[html-aria-mapping]: https://www.w3.org/TR/html-aam-1.0/#att-command-popovers
+
+{{ include "demo_kbd.vto" }}
+
+
+## Example
+
+<noscript>
+
+This example requires JavaScript to be activated.
+
+</noscript>
+
+<figure>
+	<div role=toolbar>
+		<button commandfor=dialog command=show-modal>
+			Modal
+		</button>
+		<button commandfor=popover-dialog command=show-popover>
+			Popover
+		</button>
+		<button commandfor=custom command=--my-custom-command>
+			Custom
+		</button>
+	</div>
+	<dialog id=dialog class="info" style="width: 48ch;">
+		<strong class="titlebar">Info</strong>
+		<p>Wow, that was easy!
+        <p>This dialog is not a popover, so it will require a "Close" button or pressing "Escape".
+		<div class="flex-row justify-content:end">
+			<button commandfor=dialog command=close>
+				Close
+			</button>
+		</div>
+	</dialog>
+	<dialog id=popover-dialog class="ok" popover style="width: 48ch;">
+		<strong class="titlebar">Popover Dialog</strong>
+		<p>This dialog uses the Popover API and has "light dismiss" available by clicking outside the dialog.
+        <p>The "Close" button is not required, but could be used with the <code class="token attr-value">hide-popover</code> command.
+		<div class="flex-row justify-content:end">
+			<button commandfor=popover-dialog command=hide-popover>
+				Close
+			</button>
+		</div>
+	</dialog>
+	<div id=custom hidden>
+		<script>
+			document.getElementById("custom").addEventListener("command", (e) => {
+				alert(`The custom command "${e.command}" was triggered by "${e.source}"`)
+			})
+		</script>
+	</div>
+</figure>
+
+<script type=module src=/dist/js/commandbutton.js></script>

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -28,39 +28,35 @@ To get the actual behavior of an accessible tabset, you can use [Missing.js &sec
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Tab markup</figcaption>
 
   ~~~ html
-  <script type=module src=/dist/js/tabs.js></script>
+  <script type="module" src="/dist/js/tabs.js"></script>
+  <aria-tablist aria-label="Tabs example">
+    <aria-tab aria-controls="servers" aria-selected="true"
+    >Servers</aria-tab>
+    <aria-tab aria-controls="channels"
+    >Channels</aria-tab>
+    <aria-tab aria-controls="users"
+    >Users</aria-tab>
+  </aria-tablist>
 
-  <div role=tablist aria-label="Tabs example">
-    <button role=tab aria-controls=servers aria-selected=true
-      >Servers</button>
-    <button role=tab aria-controls=channels
-      >Channels</button>
-    <button role=tab aria-controls=users
-      >Users</button>
-  </div>
-
-  <div id=servers         role=tabpanel>...</div>
-  <div id=channels hidden role=tabpanel>...</div>
-  <div id=users    hidden role=tabpanel>...</div>
+  <aria-tabpanel id="servers"        >...</aria-tabpanel>
+  <aria-tabpanel id="channels" hidden>...</aria-tabpanel>
+  <aria-tabpanel id="users"    hidden>...</aria-tabpanel>
   ~~~
 
   <hr>
 
-  <script type=module src=/dist/js/tabs.js></script>
-
-  <div role=tablist aria-label="Tabs example">
-    <button role=tab aria-controls=servers aria-selected=true
-      >Servers</button>
-    <button role=tab aria-controls=channels
-      >Channels</button>
-    <button role=tab aria-controls=users
-      >Users</button>
-  </div>
-  
-  <div id=servers         role=tabpanel>This is tab 1. <strong>JavaScript sold separately!</strong></div>
-  <div id=channels hidden role=tabpanel>You are enjoying tab 2.</div>
-  <div id=users    hidden role=tabpanel><img alt="placeholder cat" src=https://biber.denizaksimsek.com/img/IMG_2022-07-05_07-16-48-400.webp></div>
-
+  <script type="module" src="/dist/js/tabs.js"></script>
+  <aria-tablist aria-label="Tabs example" wrap>
+    <aria-tab aria-controls="servers" aria-selected="true"
+    >Servers</aria-tab>
+    <aria-tab aria-controls="channels"
+    >Channels</aria-tab>
+    <aria-tab aria-controls="users"
+    >Users</aria-tab>
+  </aria-tablist>
+  <aria-tabpanel id="servers"        >This is tab 1. <strong>JavaScript sold separately!</strong></aria-tabpanel>
+  <aria-tabpanel id="channels" hidden>You are enjoying tab 2.</aria-tabpanel>
+  <aria-tabpanel id="users"    hidden><img alt="placeholder cat" src="https://biber.denizaksimsek.com/img/IMG_2022-07-05_07-16-48-400.webp"></aria-tabpanel>
 </figure>
 
 


### PR DESCRIPTION
- added a new tag() function to 19.js to concisely define custom elements in a way that fits our existing code style
- added a focus-group element that handles roving tabindex
- reimplemented tabs as custom elements, using tag() and focusgroup