### PR TITLE
Add stylelint for CSS compat checking

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -10,8 +10,10 @@
     "www": "deno task lume",
     "lume": "cd www && echo \"import 'lume/cli.ts'\" | deno run --unstable -A -",
     "css": "deno run -qA tool/css.ts src/missing.css && deno run -qA tool/css.ts src/missing-prism.css",
-    "js": "rm -rf dist/js && cp -r src/js dist/js && cp -r dist/js www/missing-js"
+    "js": "rm -rf dist/js && cp -r src/js dist/js && cp -r dist/js www/missing-js",
+    "lint": "deno task lint-css",
+    "lint-css": "deno run -A tool/stylelint.ts"
   },
-  "nodeModulesDir": false,
+  "nodeModulesDir": "none",
   "lock": false
 }

--- a/src/components.css
+++ b/src/components.css
@@ -99,7 +99,9 @@ details,
 
 		& > :nth-child(2) {
 			overflow: auto;
+			/* doiuse-disable css-scrollbar */
       scrollbar-width: auto;
+      /* doiuse-enable css-scrollbar */
 			--full-width: calc(100vw - 25ch);
 			padding-top: var(--gap);
 		}

--- a/src/core/sanitize.css
+++ b/src/core/sanitize.css
@@ -1,3 +1,5 @@
+/* doiuse-disable css3-cursors, text-size-adjust */
+
 /* Document
  * ========================================================================== */
 

--- a/src/layout.css
+++ b/src/layout.css
@@ -1,7 +1,9 @@
 .textcolumns {
     --col-width: 30ch;
+    /* doiuse-disable multicolumn */
     column-width: var(--col-width);
     column-gap: var(--gap);
+    /* doiuse-enable multicolumn */
     margin-block: var(--gap);
 
     & :first-child { margin-block-start: 0 !important }
@@ -176,7 +178,9 @@
 
 .inline { display: inline }
 .block { display: block }
+/* doiuse-disable css-display-contents */
 .contents { display: contents }
+/* doiuse-enable css-display-contents */
 
 .table {
     display: table;

--- a/src/main.css
+++ b/src/main.css
@@ -20,12 +20,16 @@ html {
     ::-webkit-scrollbar-track { background-color: transparent;   }
   }
   @supports (scrollbar-color: gray transparent) {
+    /* doiuse-disable css-scrollbar */
     scrollbar-color: var(--accent) transparent;
+    /* doiuse-enable css-scrollbar */
   }
 }
 html, body {
+  /* doiuse-disable css-scrollbar */
   scrollbar-width: auto;
   & * { scrollbar-width: thin; }
+  /* doiuse-enable css-scrollbar */
 }
 
 body {
@@ -258,7 +262,9 @@ dl {
 		margin-inline-start: var(--rhythm, 1rlh);
 	}
 
+/* doiuse-disable css-marker-pseudo */
 li::marker {
+/* doiuse-enable css-marker-pseudo */
 	font-family: var(--secondary-font);
 }
 
@@ -575,7 +581,9 @@ label :is(input, select):not([specificity-hack]) {
 	}
 
 	&:disabled {
+	  /* doiuse-disable css3-cursors */
     cursor: not-allowed;
+	  /* doiuse-enable css3-cursors */
 		--fg: var(--muted-fg);
 		box-shadow: var(--shadow-disabled);
 	}
@@ -667,7 +675,9 @@ input::file-selector-button:active {
 	box-shadow: var(--shadow-active);
 }
 input:disabled::file-selector-button {
+  /* doiuse-disable css3-cursors */
   cursor: not-allowed;
+  /* doiuse-enable css3-cursors */
 	--fg: var(--muted-fg);
 	box-shadow: var(--shadow-disabled);
 }

--- a/tool/stylelint.ts
+++ b/tool/stylelint.ts
@@ -1,0 +1,27 @@
+import stylelint from 'npm:stylelint';
+import noUnsupportedBrowserFeatures from 'npm:stylelint-no-unsupported-browser-features';
+import { resolve } from 'jsr:@std/path/resolve'
+
+async function checkCssCompact() {
+  const result = await stylelint.lint({
+    cwd: resolve(import.meta.dirname, '../'),
+    files: 'src/**/*.css',
+    formatter: 'string',
+    config: {
+      plugins: [noUnsupportedBrowserFeatures],
+      rules: {
+        'plugin/no-unsupported-browser-features': [true, {
+          browsers: "> 0.9% and last 2 versions and not dead",
+          ignorePartialSupport: true,
+        }],
+      },
+    },
+  });
+
+  if (result.errored) {
+    console.log(result.report);
+    Deno.exit(1);
+  }
+}
+
+checkCssCompact();


### PR DESCRIPTION
Re. #70

Currently stylelint is configured to only check for compat violations, we can turn on more rules in the future.

⚠️ The stylelint compat checker plugin is based on [doiuse](https://github.com/anandthakker/doiuse), which seems lightly maintained. e.g. https://github.com/anandthakker/doiuse/issues/78 was untouched since 2017. Hopefully this won't become too much of an issue for us...