### PR TITLE
Clarify <select> changes

### DIFF
--- a/www/releases/1.2.0.md
+++ b/www/releases/1.2.0.md
@@ -88,9 +88,7 @@
 
 - Buttons now support colorways.
 
-- Added improved styling for `<select>`{.language-html} using the new
-  [customizable select](https://open-ui.org/components/customizableselect/)
-  features, as well as colorway support.
+- Added improved styling for `<select>`{.language-html} and partial colorway support.
 
 - `<dl>`{.language-html} elements with the `.textcolumns` class will now avoid
   breaking inside terms and descriptions, or between a term and its description.


### PR DESCRIPTION
The new `<select>` changes don't actually take advantage of the new `<select>` styling features.