### PR TITLE
Clarify how to override variables

### DIFF
--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -9,7 +9,7 @@ We use several CSS variables that you can override to customize your site.
 You can create multiple classes that set these variables and switch between them to create multiple themes.
 When overriding color variables, be sure to use the `light-dark()`{.language-css} CSS function in order to preserve the light/dark theme functionality.
 
-This is a reference of all the variables you can set on the root `<html>`{.language-html} element.
+This is a reference of all the variables you can set on the `:root`{.language-css} pseudo-class.
 There are a few more that are used with specific components or utility classes;
 these are grouped together at the bottom, in addition to being mentioned in the documentation for their respective class or component.
 
@@ -118,7 +118,7 @@ these are grouped together at the bottom, in addition to being mentioned in the 
 
 
 ## Borders
-   
+
 <dfn>`--border-width`</dfn> {#var-border-width}
 :   Shortcut for uniform border widths on various `.box` related components.
     Defaults to `unset`{.token .attr-value}.
@@ -227,7 +227,7 @@ these are grouped together at the bottom, in addition to being mentioned in the 
     ~~~ css
     --mono-font: "Cascadia Code", monospace, monospace
     ~~~
-    
+
     </div>
 
 


### PR DESCRIPTION
While the original line is technically correct (`:root` matches the `html` element), it's a little misleading since setting variables overrides with the `html` selector won't work; only `root` works because of the higher specificity.