### PR TITLE
Add aria-icon POC

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -1,198 +1,194 @@
-aria-tablist, [role="tablist"] {
-    display: flex;
-    gap: .5ch;
+aria-tablist, [role=tablist] {
+	display: flex;
+	gap: .5ch;
+	z-index: 2;
 }
 
-aria-tab, [role="tab"]:not([specificity-hack]) {
-    all: initial;
-    color-scheme: light dark;
+aria-tab, [role=tab]:not([specificity-hack]) {
+	all: initial;
+	color-scheme: light dark;
 
 	font-family: var(--secondary-font);
 
-    padding: 0 calc(var(--rhythm, 1rlh) / 4);
-    margin: 0;
-    min-height: var(--rhythm, 1rlh);
-    bottom: calc(-1 * var(--border-block-start-width));
-    position: relative;
+	padding: 0 calc(var(--rhythm, 1rlh) / 4);
+	margin: 0;
+	min-height: var(--rhythm, 1rlh);
+	bottom: calc(-1 * var(--border-block-start-width));
+	position: relative;
 
-    color: var(--fg);
-    border: var(--border-block-start-width) var(--border-block-start-style) var(--graphical-fg);
-    background: var(--interactive-bg);
+	color: var(--fg);
+	border: var(--border-block-start-width) var(--border-block-start-style) var(--graphical-fg);
+	background: var(--interactive-bg);
 
-    border-start-start-radius: var(--tab-border-radius);
-    border-start-end-radius: var(--tab-border-radius);
+	border-start-start-radius: var(--tab-border-radius);
+	border-start-end-radius: var(--tab-border-radius);
 
-    &:active,
-    &[aria-selected="true"] {
-        background: var(--box-bg);
-        border-block-end: var(--border-block-start-width) var(--border-block-start-style) transparent;
-    }
+	&:active,
+	&[aria-selected=true] {
+		background: var(--box-bg);
+		border-block-end: var(--border-block-start-width) var(--border-block-start-style) transparent;
+	}
 
-    &:hover {
-        background-color: var(--box-bg);
-        box-shadow: none;
-    }
+	&:hover {
+		background-color: var(--box-bg);
+		box-shadow: none;
+	}
 
-    &:focus-visible {
-        box-shadow: none;
-        color: var(--accent);
-        text-decoration: underline;
-    }
+	&:focus-visible {
+		box-shadow: none;
+		color: var(--accent);
+		text-decoration: underline;
+	}
 }
 
-aria-tabpanel, [role="tabpanel"] {
-    /* SEE components/box.css */
-
-    display: block;
-    margin-block-start: 0;
-    border-start-start-radius: 0;
-    border-start-end-radius: 0;
-    z-index: 1;
+aria-tabpanel, [role=tabpanel] {
+	/* SEE components/box.css */
+	margin-block-start: 0;
+	border-start-start-radius: 0;
+	border-start-end-radius: 0;
+	z-index: 1;
 }
 
-[role="menu"] {
-    /* SEE components/box.css */
-    position: absolute;
+aria-menulist, [role=menu] {
+	/* SEE components/box.css */
+	position: absolute;
 
-    z-index: 10;
+	z-index: 10;
 
-    padding: calc(var(--gap) / 2) 0;
-    margin: 1px 0 0 0;
+	padding: calc(var(--gap) / 2) 0;
+	margin: 1px 0 0 0;
 
-    display: flex;
-    flex-flow: column nowrap;
+	display: flex;
+	flex-flow: column nowrap;
 }
 
-[role=menuitem] {
-    padding: 0 calc(var(--gap) / 2);
+aria-menuitem, [role=menuitem] {
+	padding: 0 calc(var(--gap) / 2);
 
-    display: block;
+	display: block;
 
-    text-decoration: none;
-    border-radius: 0;
+	text-decoration: none;
+	border-radius: 0;
 
-    color: var(--fg);
+	color: var(--fg);
 
-    &:focus, &:active {
-        background: var(--accent);
-        color: var(--bg);
-    }
+	&:focus,
+	&:active {
+		background: var(--accent);
+		color: var(--bg);
+	}
 }
 
 aria-listbox, [role=listbox] {
-    /* This has been removed from docs, but we keep the styling here as a
-     * reference for future implementation.
-     */
-    list-style: none;
+	list-style: none;
 
-    aria-option, [role=option] {
-        margin-inline: calc(-1 * var(--gap));
-        padding-inline: var(--gap);
-        border-radius: 0;
+	aria-option, [role=option] {
+		margin-inline: calc(-1 * var(--gap));
+		padding-inline: var(--gap);
+		border-radius: 0;
 
-        &[aria-selected=true],
-        &[aria-checked=true] {
-            background: var(--interactive-bg);
-        }
+		&[aria-selected=true],
+		&[aria-checked=true] {
+			background: var(--interactive-bg);
+		}
 
-        &.active {
-            --temporary-bg: var(--accent);
-            --temporary-fg: var(--bg);
-            --temporary-accent: var(--muted-accent); /* TODO: was `parent-var` */
-            --temporary-muted-accent: var(--box-bg); /* TODO: was `parent-var` */
+		&.active {
+			--temporary-bg: var(--accent);
+			--temporary-fg: var(--bg);
+			--temporary-accent: var(--muted-accent); /* TODO: was `parent-var` */
+			--temporary-muted-accent: var(--box-bg); /* TODO: was `parent-var` */
 
-            background: var(--temporary-bg);
-            color: var(--temporary-fg);
+			background: var(--temporary-bg);
+			color: var(--temporary-fg);
 
-            > * {
-                --bg: var(--temporary-bg);
-                --fg: var(--temporary-fg);
-                --accent: var(--temporary-accent);
-                --muted-accent: var(--temporary-muted-accent);
-            }
-        }
-    }
+			> * {
+				--bg: var(--temporary-bg);
+				--fg: var(--temporary-fg);
+				--accent: var(--temporary-accent);
+				--muted-accent: var(--temporary-muted-accent);
+			}
+		}
+	}
 }
 
 
-[aria-orientation="vertical"] {
-    flex-direction: column;
-    width: fit-content;
-    text-align: center;
+[aria-orientation=vertical] {
+	flex-direction: column;
+	width: fit-content;
+	text-align: center;
 }
 
 
 input[type=checkbox][role=switch] {
-  all: unset;
-  appearance: none;
+	all: unset;
+	appearance: none;
 
-  display: inline-grid;
-  vertical-align: middle;
-  grid-template-columns: repeat(2, 1rem);
-  aspect-ratio: 2 / 1;
-  margin-block: auto;
+	display: inline-grid;
+	vertical-align: middle;
+	grid-template-columns: repeat(2, 1rem);
+	aspect-ratio: 2 / 1;
+	margin-block: auto;
 
-  &::before, &::after {
-    content: '';
-    display: inline-block;
+	&::before, &::after {
+		content: '';
+		display: inline-block;
 
-    transition: transform .2s ease-in-out, background-color .2s ease-in-out, background-color .2s ease-in-out;
-  }
+		transition: transform .2s ease-in-out, background-color .2s ease-in-out, background-color .2s ease-in-out;
+	}
 
-  &::before {
-    grid-column: 1 / span 2;
-    grid-row: 1;
-    border: var(--interactive-border-width) var(--interactive-border-style) var(--graphical-fg);
-    background: var(--bg);
-    border-radius: 9999rem;
-  }
+	&::before {
+		grid-column: 1 / span 2;
+		grid-row: 1;
+		border: var(--interactive-border-width) var(--interactive-border-style) var(--graphical-fg);
+		background: var(--bg);
+		border-radius: 9999rem;
+	}
 
-  &::after {
-    --toggle-nub-margin: 2px;
-    grid-column: 1;
-    grid-row: 1;
-    margin: var(--toggle-nub-margin);
-    border-radius: 99999rem;
-    background: var(--graphical-fg);
-  }
+	&::after {
+		--toggle-nub-margin: 2px;
+		grid-column: 1;
+		grid-row: 1;
+		margin: var(--toggle-nub-margin);
+		border-radius: 99999rem;
+		background: var(--graphical-fg);
+	}
 
-  &:checked {
-    &::before {
-      border-color: var(--accent);
-      background: var(--accent);
-    }
-    &::after {
-      transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
-      background: var(--bg);
-    }
-  }
+	&:checked {
+		&::before {
+			border-color: var(--accent);
+			background: var(--accent);
+		}
+		&::after {
+			transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
+			background: var(--bg);
+		}
+	}
 
-  &:indeterminate {
-    &::before {
-      border: var(--interactive-border-width) var(--interactive-border-style) var(--interactive-bg);
-    }
-    &::after {
-      transform: translateX(calc(50% + var(--toggle-nub-margin)));
-      background: var(--interactive-bg);
-    }
-  }
+	&:indeterminate {
+		&::before {
+			border: var(--interactive-border-width) var(--interactive-border-style) var(--interactive-bg);
+		}
+		&::after {
+			transform: translateX(calc(50% + var(--toggle-nub-margin)));
+			background: var(--interactive-bg);
+		}
+	}
 
-  &:is(label > *):not(#specificity-hack) {
-    margin-block-end: auto;
+	&:is(label > *):not(#specificity-hack) {
+		margin-block-end: auto;
   }
   &:not(label > *) {
-    padding-block: calc(var(--gap) / 4 + (var(--rhythm, 1rlh) - 1em) / 2);
+		padding-block: calc(var(--gap) / 4 + (var(--rhythm, 1rlh) - 1em) / 2);
   }
 
   :is(label:has(> &)) {
-    /* Lightning CSS requires :is() when nested selector doesn't start with & */
-    display: flex;
-    gap: var(--gap);
-    flex-direction: row;
+		/* Lightning CSS requires :is() when nested selector doesn't start with & */
+		display: flex;
+		gap: var(--gap);
+		flex-direction: row;
   }
   :is(label:has(+ &)) {
-    /* Lightning CSS requires :is() when nested selector doesn't start with & */
-    width: 100%;
+	  /* Lightning CSS requires :is() when nested selector doesn't start with & */
+	  width: 100%;
   }
-
 }

--- a/src/js/icon.js
+++ b/src/js/icon.js
@@ -4,15 +4,17 @@ import { css, makelogger, on, tag } from "./19.js"
 const ilog = makelogger("icons")
 const cache = new Map()
 
-// https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
-// https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
-const min_size = 24  // TODO: Use WCAG21 or WCAG22? 24px or 44px?
+// ref: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+const minSize = 24
+
+const latest = "0.552.0"  // Avoid CDN redirect
+const url = `https://unpkg.com/lucide-static@${latest}/icons/`
 
 export const icon = tag(
   "aria-icon",
   {
     internals: { ariaHidden: "true" },
-    observedAttributes: ["name", "size", "fetch"],
+    observedAttributes: ["name"],
     css: css`
       :host {
         display: inline-flex;
@@ -20,92 +22,94 @@ export const icon = tag(
         justify-content: center;
         font-size: inherit;
         line-height: 1;
-        width: 1em; height: 1em;  // Avoid reflow
-      }
-      svg {
         width: 1em;
         height: 1em;
-        fill: none;
-        stroke: currentColor;
-        stroke-width: 2;
-        stroke-linecap: round;
-        stroke-linejoin: round;
+      }
+      svg {
+        width: 100%;
+        height: 100%;
+        fill: var(--icon-fill, none);
+        stroke: var(--icon-stroke, currentColor);
+        stroke-width: var(--icon-stroke-width, 2px);
+        stroke-linecap: var(--icon-stroke-linecap, round);
+        stroke-linejoin: var(--icon-stroke-linejoin, round);
       }
     `,
   },
   (icon) => {
 
-    async function fetchIcon(name) {
-      if (!name) return
+    const fetchIcon = async (name) => {
+      if (name) name = name.replace("lucide-", "")
+      else return ""
+
       if (cache.has(name)) {
         const cached = cache.get(name)
         return (typeof cached === "string") ? cached : await cached
       }
 
-      const url = `https://unpkg.com/lucide-static@latest/icons/${name}.svg`
-
-      const pendingFetch = (async () => {
+      const result = (async () => {
+        let str = ""
         try {
-          const response = await fetch(url)
-
-          if (!response.ok)
-            return console.error(`Icon "${name}" not found (${url}).`), ""
-
-          const svg = await response.text()
-          cache.set(name, svg)
-          return svg
+          const response = await fetch(`${url}${name}.svg`)
+          if (response.ok)
+            str = await response.text()
+          else throw new Error(`HTTP Error ${response.status}: ${response.url}.`)
         } catch (error) {
-          console.error(`Failed to fetch "${url}"`, error)
-          cache.set(name, "")
-          return ""
+          console.error(`Failed to load icon "${name}".`, error)
         }
+        cache.set(name, str)
+        return str
       })()
 
-      cache.set(name, pendingFetch)
-      return pendingFetch
+      cache.set(name, result)
+      return result
     }
 
+    const useIcon = (name) => `
+      <!-- @license lucide-static v0.552.0 - ISC -->
+      <svg
+        class="lucide lucide-${name}"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+      >
+        <!-- TODO: really only need to define this once... -->
+        <style>symbol[id^=lucide] > * {
+          fill: var(--icon-fill, none);
+          stroke: var(--icon-stroke, currentColor);
+          stroke-width: var(--icon-stroke-width, 2px);
+          stroke-linecap: var(--icon-stroke-linecap, round);
+          stroke-linejoin: var(--icon-stroke-linejoin, round);
+        }</style>
+        <use href="#${name}"/>
+      </svg>`
+
     const validate = () => {
-      const button = icon.parentElement
-      if (!(button instanceof HTMLButtonElement || button.getAttribute("role") === "button"))
+      const clickable = icon.parentElement
+      if (!(clickable instanceof HTMLButtonElement || clickable instanceof HTMLAnchorElement))
         return
 
-      const rect = button.getBoundingClientRect()
-      if (rect.width < min_size || rect.height < min_size)
-        console.warn(icon.parentElement, `The recommended touch target size is ${min_size}px x ${min_size}px.`)
-      if (!(button.hasAttribute("aria-label") || button.textContent.trim()))
-        console.error(button, "has no accessible label (aria-label or text content).")
+      const rect = clickable.getBoundingClientRect()
+      if (rect.width < minSize || rect.height < minSize)
+        console.warn(icon.parentElement,
+          `WCAG 2.2 minimum target size is ${minSize}px x ${minSize}px.`
+        )
+      if (!(clickable.hasAttribute("aria-label") || clickable.textContent.trim()))
+        console.error(clickable,
+          "has no accessible label (aria-label or text content)."
+        )
     }
 
     const render = async () => {
-      validate()
       const name = icon.getAttribute("name")
-      const svg = (icon.hasAttribute("fetch"))
-        ? await fetchIcon(name)
-        : `
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <use href="#${name}"/>
-          </svg>
-        `
-      icon.innerHTML = svg
-
-      // TODO: Strip outer `<svg>` when fetching to eliminate need to resize?
       if (icon.hasAttribute("fetch"))
-        resize()
+        icon.shadowRoot.innerHTML = await fetchIcon(name)
+      else
+        // <use href> can't resolve in ShadowDOM :(
+        icon.innerHTML = useIcon(name)
     }
 
-    const resize = () => {
-      validate()
-      const size = icon.getAttribute("size") || "1em"
-      const svg = icon.querySelector("svg")
-      if (svg)
-        svg.style.width = svg.style.height = size
-    }
-
-    on(icon, "connected", validate)
-    on(icon, "attribute:name", render)
-    on(icon, "attribute:fetch", render)
-    on(icon, "attribute:size", resize)
+    on(icon, "connected", (e) => validate())
+    on(icon, "attribute:name", (e) => render())
   }
 )
 

--- a/src/js/icon.js
+++ b/src/js/icon.js
@@ -14,7 +14,7 @@ export const icon = tag(
   "aria-icon",
   {
     internals: { ariaHidden: "true" },
-    observedAttributes: ["name"],
+    observedAttributes: ["name", "aria-label", "aria-labelledby"],
     css: css`
       :host {
         display: inline-flex;
@@ -108,8 +108,17 @@ export const icon = tag(
         icon.innerHTML = useIcon(name)
     }
 
+    const label = (value) => {
+      Object.assign(icon.internals, {
+        ariaHidden: (value) ? "false" : "true",
+        role: (value) ? "img" : null,
+      })
+    }
+
     on(icon, "connected", (e) => validate())
     on(icon, "attribute:name", (e) => render())
+    on(icon, "attribute:aria-label", (e) => label(e.detail.value))
+    on(icon, "attribute:aria-labelledby", (e) => label(e.detail.value))
   }
 )
 

--- a/src/js/icon.js
+++ b/src/js/icon.js
@@ -1,0 +1,112 @@
+//@deno-types=./19.ts
+import { css, makelogger, on, tag } from "./19.js"
+
+const ilog = makelogger("icons")
+const cache = new Map()
+
+// https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
+// https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html
+const min_size = 24  // TODO: Use WCAG21 or WCAG22? 24px or 44px?
+
+export const icon = tag(
+  "aria-icon",
+  {
+    internals: { ariaHidden: "true" },
+    observedAttributes: ["name", "size", "fetch"],
+    css: css`
+      :host {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: inherit;
+        line-height: 1;
+        width: 1em; height: 1em;  // Avoid reflow
+      }
+      svg {
+        width: 1em;
+        height: 1em;
+        fill: none;
+        stroke: currentColor;
+        stroke-width: 2;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+    `,
+  },
+  (icon) => {
+
+    async function fetchIcon(name) {
+      if (!name) return
+      if (cache.has(name)) {
+        const cached = cache.get(name)
+        return (typeof cached === "string") ? cached : await cached
+      }
+
+      const url = `https://unpkg.com/lucide-static@latest/icons/${name}.svg`
+
+      const pendingFetch = (async () => {
+        try {
+          const response = await fetch(url)
+
+          if (!response.ok)
+            return console.error(`Icon "${name}" not found (${url}).`), ""
+
+          const svg = await response.text()
+          cache.set(name, svg)
+          return svg
+        } catch (error) {
+          console.error(`Failed to fetch "${url}"`, error)
+          cache.set(name, "")
+          return ""
+        }
+      })()
+
+      cache.set(name, pendingFetch)
+      return pendingFetch
+    }
+
+    const validate = () => {
+      const button = icon.parentElement
+      if (!(button instanceof HTMLButtonElement || button.getAttribute("role") === "button"))
+        return
+
+      const rect = button.getBoundingClientRect()
+      if (rect.width < min_size || rect.height < min_size)
+        console.warn(icon.parentElement, `The recommended touch target size is ${min_size}px x ${min_size}px.`)
+      if (!(button.hasAttribute("aria-label") || button.textContent.trim()))
+        console.error(button, "has no accessible label (aria-label or text content).")
+    }
+
+    const render = async () => {
+      validate()
+      const name = icon.getAttribute("name")
+      const svg = (icon.hasAttribute("fetch"))
+        ? await fetchIcon(name)
+        : `
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+            <use href="#${name}"/>
+          </svg>
+        `
+      icon.innerHTML = svg
+
+      // TODO: Strip outer `<svg>` when fetching to eliminate need to resize?
+      if (icon.hasAttribute("fetch"))
+        resize()
+    }
+
+    const resize = () => {
+      validate()
+      const size = icon.getAttribute("size") || "1em"
+      const svg = icon.querySelector("svg")
+      if (svg)
+        svg.style.width = svg.style.height = size
+    }
+
+    on(icon, "connected", validate)
+    on(icon, "attribute:name", render)
+    on(icon, "attribute:fetch", render)
+    on(icon, "attribute:size", resize)
+  }
+)
+
+icon.define()

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -339,6 +339,7 @@ This is because many assistive programs have a feature to jump to the navigation
 <dfn>`.iconbutton`</dfn> creates a bare icon; it even works with the `.<button>`{.language-css} and `.<big>` masquerades!
 [Colorways][colorway] are supported as well.
 We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
+<script type=module src=/dist/js/icon.js></script>
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Icon button markup</figcaption>
@@ -347,7 +348,7 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   <!-- sprite sheet -->
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <defs>
-      <symbol id="menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
+      <symbol id="lucide-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
       <!-- ... --->
     </defs>
   </svg>
@@ -357,10 +358,12 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   <!-- markup.html -->
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      // OLD: <svg aria-hidden=true><use href=#lucide-menu></use></svg>
+      <aria-icon name=lucide-menu></aria-icon>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      // OLD: <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
+      <aria-icon name=lucide-arrow-big-right></aria-icon>
     </a>
     <!-- ... -->
   </section>
@@ -370,38 +373,66 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
   <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
     <defs>
-      <symbol id="menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu-icon lucide-menu"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
-      <symbol id="next-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-big-right-icon lucide-arrow-big-right"><path d="M6 9h6V5l7 7-7 7v-4H6V9z"/></symbol>
-      <symbol id="cut-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-scissors-icon lucide-scissors"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></symbol>
-      <symbol id="close-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
-      <symbol id="trans-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-transgender-icon lucide-transgender"><path d="M12 16v6"/><path d="M14 20h-4"/><path d="M18 2h4v4"/><path d="m2 2 7.17 7.17"/><path d="M2 5.355V2h3.357"/><path d="m22 2-7.17 7.17"/><path d="M8 5 5 8"/><circle cx="12" cy="12" r="4"/></symbol>
-      <symbol id="smile-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-smile-icon lucide-smile"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></symbol>
-      <symbol id="music-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-music-icon lucide-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></symbol>
+      <symbol id="lucide-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu-icon lucide-menu"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
+      <symbol id="lucide-arrow-big-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-big-right-icon lucide-arrow-big-right"><path d="M6 9h6V5l7 7-7 7v-4H6V9z"/></symbol>
+      <symbol id="lucide-scissors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-scissors-icon lucide-scissors"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></symbol>
+      <symbol id="lucide-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
+      <symbol id="lucide-transgender" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-transgender-icon lucide-transgender"><path d="M12 16v6"/><path d="M14 20h-4"/><path d="M18 2h4v4"/><path d="m2 2 7.17 7.17"/><path d="M2 5.355V2h3.357"/><path d="m22 2-7.17 7.17"/><path d="M8 5 5 8"/><circle cx="12" cy="12" r="4"/></symbol>
+      <symbol id="lucide-smile" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-smile-icon lucide-smile"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></symbol>
+      <symbol id="lucide-music" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-music-icon lucide-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></symbol>
     </defs>
   </svg>
+  <!--
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-menu></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-scissors></use></svg>
     </button>
     <a class="warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-x></use></svg>
     </a>
     <button class="bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-transgender></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-smile></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-music></use></svg>
     </button>
   </section>
+  -->
+
+  <section class="flex-row justify-content:space-between">
+    <button class="iconbutton" type=button aria-label="Menu">
+      <aria-icon fetch name=menu></aria-icon>
+    </button>
+    <a class="info <button> iconbutton" aria-label="Next">
+      <aria-icon fetch name=arrow-big-right></aria-icon>
+    </button>
+    </a>
+    <button class="ok iconbutton" type=button aria-label="Cut">
+      <aria-icon fetch name=scissors></aria-icon>
+    </button>
+    <a class="warn <button> iconbutton" aria-label="Close">
+      <aria-icon fetch name=x></aria-icon>
+    </a>
+    <button class="bad iconbutton" type=button aria-label="Trans">
+      <aria-icon fetch name=transgender></aria-icon>
+    </button>
+    <a class="info <button> iconbutton" aria-label="Smile">
+      <aria-icon fetch name=smile></aria-icon>
+    </a>
+    <button class="ok iconbutton" type=button aria-label="Music">
+      <aria-icon fetch name=music></aria-icon>
+    </button>
+  </section>
+
 
 </figure>
 
@@ -411,7 +442,8 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   ~~~ html
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      // OLD: <svg aria-hidden=true><use href=#lucide-menu></use></svg>
+      <aria-icon fetch name=menu></aria-icon>
     </button>
     <!-- ... -->
   </section>
@@ -419,27 +451,52 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
   <hr>
 
+  <!--
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-menu></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-scissors></use></svg>
     </button>
     <a class="<big> warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-x></use></svg>
     </a>
     <button class="<big> bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-transgender></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-smile></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg aria-hidden=true><use href=#lucide-music></use></svg>
+    </button>
+  </section>
+  -->
+  <section class="flex-row justify-content:space-between">
+    <button class="<big> iconbutton" type=button aria-label="Menu">
+      <aria-icon name=lucide-menu></aria-icon>
+    </button>
+    <a class="<big> info <button> iconbutton" aria-label="Next">
+      <aria-icon name=lucide-arrow-big-right></aria-icon>
+    </a>
+    <button class="<big> ok iconbutton" type=button aria-label="Cut">
+      <aria-icon name=lucide-scissors></aria-icon>
+    </button>
+    <a class="<big> warn <button> iconbutton" aria-label="Close">
+      <aria-icon name=lucide-x></aria-icon>
+    </a>
+    <button class="<big> bad iconbutton" type=button aria-label="Trans">
+      <aria-icon name=lucide-transgender></aria-icon>
+    </button>
+    <a class="<big> info <button> iconbutton" aria-label="Smile">
+      <aria-icon name=lucide-smile></aria-icon>
+    </a>
+    <button class="<big> ok iconbutton" type=button aria-label="Music">
+      <aria-icon name=lucide-music></aria-icon>
     </button>
   </section>
 

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -345,10 +345,10 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Icon button markup</figcaption>
 
   ~~~ html
-  <!-- sprite sheet -->
-  <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <!-- sprite sheet from https://icones.js.org/collection/lucide -->
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: none">
     <defs>
-      <symbol id="lucide-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
+      <symbol viewBox="0 0 24 24" id="lucide-arrow-big-right"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9h6V5l7 7l-7 7v-4H6z"></path></symbol>
       <!-- ... --->
     </defs>
   </svg>
@@ -358,11 +358,9 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   <!-- markup.html -->
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      // OLD: <svg aria-hidden=true><use href=#lucide-menu></use></svg>
       <aria-icon name=lucide-menu></aria-icon>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      // OLD: <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
       <aria-icon name=lucide-arrow-big-right></aria-icon>
     </a>
     <!-- ... -->
@@ -370,44 +368,18 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   ~~~
 
   <hr>
-
-  <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
-    <defs>
-      <symbol id="lucide-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu-icon lucide-menu"><path d="M4 12h16"/><path d="M4 18h16"/><path d="M4 6h16"/></symbol>
-      <symbol id="lucide-arrow-big-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-big-right-icon lucide-arrow-big-right"><path d="M6 9h6V5l7 7-7 7v-4H6V9z"/></symbol>
-      <symbol id="lucide-scissors" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-scissors-icon lucide-scissors"><circle cx="6" cy="6" r="3"/><path d="M8.12 8.12 12 12"/><path d="M20 4 8.12 15.88"/><circle cx="6" cy="18" r="3"/><path d="M14.8 14.8 20 20"/></symbol>
-      <symbol id="lucide-x" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-x-icon lucide-x"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></symbol>
-      <symbol id="lucide-transgender" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-transgender-icon lucide-transgender"><path d="M12 16v6"/><path d="M14 20h-4"/><path d="M18 2h4v4"/><path d="m2 2 7.17 7.17"/><path d="M2 5.355V2h3.357"/><path d="m22 2-7.17 7.17"/><path d="M8 5 5 8"/><circle cx="12" cy="12" r="4"/></symbol>
-      <symbol id="lucide-smile" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-smile-icon lucide-smile"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" x2="9.01" y1="9" y2="9"/><line x1="15" x2="15.01" y1="9" y2="9"/></symbol>
-      <symbol id="lucide-music" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-music-icon lucide-music"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></symbol>
-    </defs>
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="display: none">
+  <defs>
+  <symbol viewBox="0 0 24 24" id="lucide-arrow-big-right"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 9h6V5l7 7l-7 7v-4H6z"></path></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-menu"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 12h16M4 6h16M4 18h16"></path></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-music"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></g></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-scissors"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="6" cy="6" r="3"></circle><path d="M8.12 8.12L12 12m8-8L8.12 15.88"></path><circle cx="6" cy="18" r="3"></circle><path d="M14.8 14.8L20 20"></path></g></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-smile"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><circle cx="12" cy="12" r="10"></circle><path d="M8 14s1.5 2 4 2s4-2 4-2M9 9h.01M15 9h.01"></path></g></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-transgender"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"><path d="M12 16v6m2-2h-4m8-18h4v4M2 2l7.17 7.17M2 5.355V2h3.357M22 2l-7.17 7.17M8 5L5 8"></path><circle cx="12" cy="12" r="4"></circle></g></symbol>
+  <symbol viewBox="0 0 24 24" id="lucide-x"><!-- Icon from Lucide by Lucide Contributors - https://github.com/lucide-icons/lucide/blob/main/LICENSE --><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 6L6 18M6 6l12 12"></path></symbol>
+  
+  </defs>
   </svg>
-  <!--
-  <section class="flex-row justify-content:space-between">
-    <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#lucide-menu></use></svg>
-    </button>
-    <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
-    </a>
-    <button class="ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#lucide-scissors></use></svg>
-    </button>
-    <a class="warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#lucide-x></use></svg>
-    </a>
-    <button class="bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#lucide-transgender></use></svg>
-    </button>
-    <a class="info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#lucide-smile></use></svg>
-    </a>
-    <button class="ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#lucide-music></use></svg>
-    </button>
-  </section>
-  -->
-
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
       <aria-icon fetch name=menu></aria-icon>
@@ -442,7 +414,6 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   ~~~ html
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      // OLD: <svg aria-hidden=true><use href=#lucide-menu></use></svg>
       <aria-icon fetch name=menu></aria-icon>
     </button>
     <!-- ... -->
@@ -451,31 +422,6 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
   <hr>
 
-  <!--
-  <section class="flex-row justify-content:space-between">
-    <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#lucide-menu></use></svg>
-    </button>
-    <a class="<big> info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#lucide-arrow-big-right></use></svg>
-    </a>
-    <button class="<big> ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#lucide-scissors></use></svg>
-    </button>
-    <a class="<big> warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#lucide-x></use></svg>
-    </a>
-    <button class="<big> bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#lucide-transgender></use></svg>
-    </button>
-    <a class="<big> info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#lucide-smile></use></svg>
-    </a>
-    <button class="<big> ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#lucide-music></use></svg>
-    </button>
-  </section>
-  -->
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
       <aria-icon name=lucide-menu></aria-icon>


### PR DESCRIPTION
I had an idea for making lucide easier to implement last night and ran with it. This is a proof of concept, hoping to get feedback to see if this approach is viable.

- View it in action in the docs page for components.
- `<aria-icon name="idref">` will attempt to add in a `<use href=idref>` if a sprite sheet is available in the markup. **Update**: Since `<use href>` will not resolve in the ShadowDOM, it must be placed in the LightDOM.
- `<aria-icon name="foo" fetch>` will attempt to fetch the svg from Lucide's unpkg CDN. There is a cache to avoid duplicate concurrent hits, and browsers also implement cache to cut down on actual requests for previously downloaded icons.
- Sets `aria-hidden="true"` on ElementInternals
- Validates labeling and WCAG 2.2 minimum touch size if icon is in a `<button>` or `<a>` tag.

There's a bit of cleanup that could be done:

- [ ] Spritesheets will need `name` to be namespaced, probably `<symbol id=lucide-menu>` etc, whereas fetch just uses the icon name `name=menu fetch`). 
- [x] Fetch currently needs to call `resize()` after bc the response is an `<svg>` with width/height set. Perhaps I can strip the outer element or find another way to set size.~~ **Update:** No longer necessary, icons are sized according to the size of `<aria-icon>`.
- [x] I'm not 100% with the `pendingFetch()` function yet, but this is kind of my first foray into using async+caching in javascript, so it's a learning process. **Update:** Got this simplified to something I like.
- [x] Support validation on `<a class="<button>">`

Since `<use href>` won't resolve in the ShadowDOM, I had to include a `<style>` sheet defining the CSS variables (`--icon-stroke-width`, etc). Currently, this is injected alongside every `<use>` tag, which isn't ideal. Trying to figure out how to best only set it once. Not sure if injecting a `<style id=aria-icon-styles></style>` into `<head>` is acceptable or not.