### PR TITLE
docs: fix SVG viewBox in icon button examples

### DIFF
--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,7 +5,7 @@ BROWSERSLIST="> 0.9% and last 2 versions and not dead"
 [tools]
 node = "latest"
 deno = "2.4"
-# esbuild = "0.25.8"
+esbuild = "0.25.8"
 
 
 [tasks]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "missing.css",
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "missing.css",
+      "version": "1.2.0",
+      "license": "BSD 2-Clause"
+    }
+  }
+}

--- a/src/aria.css
+++ b/src/aria.css
@@ -121,12 +121,19 @@
 
 
 input[type=checkbox][role=switch] {
+  --toggle-track-border-color: var(--graphical-fg);
+  --toggle-track-background: var(--bg);
+
+  --toggle-nub-margin: 2px;
+  --toggle-nub-background: var(--graphical-fg);
+
   all: unset;
   appearance: none;
 
   display: inline-grid;
   vertical-align: middle;
   grid-template-columns: repeat(2, 1rem);
+
   aspect-ratio: 2 / 1;
   margin-block: auto;
   isolation: isolate;
@@ -141,49 +148,41 @@ input[type=checkbox][role=switch] {
   &::before {
     grid-column: 1 / span 2;
     grid-row: 1;
-    border: var(--interactive-border-width) var(--interactive-border-style) var(--graphical-fg);
-    background: var(--bg);
+    border: var(--interactive-border-width) var(--interactive-border-style) var(--toggle-track-border-color);
+    background: var(--toggle-track-background);
     border-radius: 9999rem;
   }
 
   &::after {
-    --toggle-nub-margin: 2px;
     grid-column: 1;
     grid-row: 1;
     margin: var(--toggle-nub-margin);
     border-radius: 99999rem;
-    background: var(--graphical-fg);
+    background: var(--toggle-nub-background);
     z-index: 2;
   }
 
   &:checked {
-    &::before {
-      border-color: var(--accent);
-      background: var(--accent);
-    }
+    --toggle-track-border-color: var(--accent);
+    --toggle-track-background: var(--accent);
+    --toggle-nub-background: var(--bg);
     &::after {
       transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
-      background: var(--bg);
-    }
-  }
-  
-  &:focus-visible {
-    &::before {
-      outline: .2em solid var(--accent);
-    }
-    &[checked]::before {
-      outline: .1em solid var(--accent);
-      outline-offset: .1em;
     }
   }
 
   &:indeterminate {
-    &::before {
-      border: var(--interactive-border-width) var(--interactive-border-style) var(--interactive-bg);
-    }
+    --toggle-track-border-color: var(--interactive-bg);
+    --toggle-nub-background: var(--interactive-bg);
     &::after {
       transform: translateX(calc(50% + var(--toggle-nub-margin)));
-      background: var(--interactive-bg);
+    }
+  }
+
+  &:focus-visible {
+    --toggle-track-border-color: var(--bg);
+    &::before {
+      outline: .2em solid var(--accent);
     }
   }
 

--- a/src/aria.css
+++ b/src/aria.css
@@ -129,6 +129,7 @@ input[type=checkbox][role=switch] {
   grid-template-columns: repeat(2, 1rem);
   aspect-ratio: 2 / 1;
   margin-block: auto;
+  isolation: isolate;
 
   &::before, &::after {
     content: '';
@@ -152,6 +153,7 @@ input[type=checkbox][role=switch] {
     margin: var(--toggle-nub-margin);
     border-radius: 99999rem;
     background: var(--graphical-fg);
+    z-index: 2;
   }
 
   &:checked {
@@ -162,6 +164,16 @@ input[type=checkbox][role=switch] {
     &::after {
       transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
       background: var(--bg);
+    }
+  }
+  
+  &:focus-visible {
+    &::before {
+      outline: .2em solid var(--accent);
+    }
+    &[checked]::before {
+      outline: .1em solid var(--accent);
+      outline-offset: .1em;
     }
   }
 

--- a/src/main.css
+++ b/src/main.css
@@ -760,14 +760,25 @@ input[type="file"] {
 }
 
 select {
-	/* UAs force `line-height: normal` instead of `inherit` */
-	height: calc(
-		2 * var(--interactive-border-width)  /* Top and bottom borders */
-		+ 3/2 * var(--rhythm, 1lh)           /* Plus line height and padding-block */
-	);
-
 	background: var(--bg);
 	color: var(--fg);
+
+	&[multiple] {
+		vertical-align: top;
+	}
+
+	&:not([multiple]) {
+		/* UAs force `line-height: normal` instead of `inherit` */
+		height: calc(
+			2 * var(--interactive-border-width)  /* Top and bottom borders */
+			+ 3/2 * var(--rhythm, 1lh)           /* Plus line height and padding-block */
+		);
+	}
+
+	optgroup::before {
+		color: var(--muted-fg);
+		font-style: normal;
+	}
 
 	& option {
 		background: inherit;
@@ -775,21 +786,11 @@ select {
 		border: inherit;
 
 		&:hover {
-			/* This currently doesn't do anything */
+			/* This currently only applies to select[multiple] */
 			background: var(--accent);
 			color: var(--bg);
 		}
 	}
-
-}
-
-select[multiple] {
-	vertical-align: top;
-}
-
-optgroup::before {
-	color: var(--muted-fg);
-	font-style: normal;
 }
 
 meter, progress {

--- a/src/main.css
+++ b/src/main.css
@@ -1038,6 +1038,6 @@ dialog:is([open], [popover])::backdrop {
 }
 
 dialog:not([popover], [open]),
-[popover]:not(:popover-over) {
+[popover]:not(:popover-open) {
     display: none;
 }

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -357,10 +357,10 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   <!-- markup.html -->
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <!-- ... -->
   </section>
@@ -381,25 +381,25 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   </svg>
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#cut-icon></use></svg>
     </button>
     <a class="warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#close-icon></use></svg>
     </a>
     <button class="bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#trans-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#smile-icon></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#music-icon></use></svg>
     </button>
   </section>
 
@@ -411,7 +411,7 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   ~~~ html
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <!-- ... -->
   </section>
@@ -421,25 +421,25 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#cut-icon></use></svg>
     </button>
     <a class="<big> warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#close-icon></use></svg>
     </a>
     <button class="<big> bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#trans-icon></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#smile-icon></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#music-icon></use></svg>
     </button>
   </section>
 


### PR DESCRIPTION
The svg examples in the components docs file did not set a viewBox on the svg components which resulted them in having a hover target that was much taller than the button in both directions.

This change explicitly sets the viewBox of `0 0 24 24` on each svg icon.

Before:
<img width="998" height="381" alt="Screenshot 2025-11-08 at 15 43 20" src="https://github.com/user-attachments/assets/12e32f8f-ccd5-437a-a21d-3704cb1d7d1d" />

After:
<img width="1001" height="298" alt="Screenshot 2025-11-08 at 15 44 39" src="https://github.com/user-attachments/assets/02108b00-a766-461b-b140-0c96f36def7d" />
