### PR TITLE
docs: fix SVG viewBox in icon button examples

### DIFF
--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -357,10 +357,10 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   <!-- markup.html -->
   <section class="flex-row justify-content:space-between">
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <!-- ... -->
   </section>
@@ -381,25 +381,25 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   </svg>
   <section class="flex-row justify-content:space-between" role=toolbar>
     <button class="iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#cut-icon></use></svg>
     </button>
     <a class="warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#close-icon></use></svg>
     </a>
     <button class="bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#trans-icon></use></svg>
     </button>
     <a class="info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#smile-icon></use></svg>
     </a>
     <button class="ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#music-icon></use></svg>
     </button>
   </section>
 
@@ -411,7 +411,7 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
   ~~~ html
   <section class="flex-row justify-content:space-between">
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <!-- ... -->
   </section>
@@ -421,25 +421,25 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
   <section class="flex-row justify-content:space-between" role=toolbar>
     <button class="<big> iconbutton" type=button aria-label="Menu">
-      <svg aria-hidden=true><use href=#menu-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#menu-icon></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Next">
-      <svg aria-hidden=true><use href=#next-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#next-icon></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Cut">
-      <svg aria-hidden=true><use href=#cut-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#cut-icon></use></svg>
     </button>
     <a class="<big> warn <button> iconbutton" aria-label="Close">
-      <svg aria-hidden=true><use href=#close-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#close-icon></use></svg>
     </a>
     <button class="<big> bad iconbutton" type=button aria-label="Trans">
-      <svg aria-hidden=true><use href=#trans-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#trans-icon></use></svg>
     </button>
     <a class="<big> info <button> iconbutton" aria-label="Smile">
-      <svg aria-hidden=true><use href=#smile-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#smile-icon></use></svg>
     </a>
     <button class="<big> ok iconbutton" type=button aria-label="Music">
-      <svg aria-hidden=true><use href=#music-icon></use></svg>
+      <svg viewBox="0 0 24 24" aria-hidden=true><use href=#music-icon></use></svg>
     </button>
   </section>
 


### PR DESCRIPTION
The following is from @dhartunian (PR #145); I had to cherry-pick to avoid picking up some commits in `dev`.

> The svg examples in the components docs file did not set a viewBox on the svg components which resulted them in having a hover target that was much taller than the button in both directions.
> 
> This change explicitly sets the viewBox of `0 0 24 24` on each svg icon.