### PR TITLE
Style ALL the selects

### DIFF
--- a/src/components.css
+++ b/src/components.css
@@ -88,7 +88,7 @@ details,
 
 	@media (min-width: 75ch) {
 		display: grid;
-		grid-template-columns: 25ch auto;
+		grid-template-columns: var(--sidebar-width) auto;
 		inset: 0;
 
 		& > header {
@@ -100,7 +100,12 @@ details,
 		& > :nth-child(2) {
 			overflow: auto;
       scrollbar-width: auto;
-			--full-width: calc(100vw - 25ch);
+			--full-width: calc(100vw - var(--sidebar-width));
+    	--eff-line-length: /* Effective line length for prose. */
+    		min(
+    			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+    			var(--line-length)
+    		);
 			padding-top: var(--gap);
 		}
 	}

--- a/src/layout.css
+++ b/src/layout.css
@@ -45,6 +45,12 @@
 /**/
 
 .container {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+
 	max-inline-size: var(--eff-line-length);
 	margin-inline: auto;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -734,10 +734,8 @@ textarea {
 	border: var(--interactive-border-width) var(--interactive-border-style) var(--graphical-fg);
 	border-radius: var(--interactive-border-radius);
 
-	vertical-align: top;
-
 	&:focus-visible {
-		border: var(--interactive-border-width) var(--interactive-border-style) var(--accent);
+		border-color: var(--accent);
 	}
 
 	&::placeholder {
@@ -772,37 +770,69 @@ input[type="file"] {
 }
 
 select {
-	background: var(--bg);
-	color: var(--fg);
+  scrollbar-color: var(--accent) transparent;
 
-	&[multiple] {
-		vertical-align: top;
-	}
+  &:is([multiple], [size]) {
+    padding: 0;
 
-	&:not([multiple]) {
-		/* UAs force `line-height: normal` instead of `inherit` */
-		height: calc(
-			2 * var(--interactive-border-width)  /* Top and bottom borders */
-			+ 3/2 * var(--rhythm, 1lh)           /* Plus line height and padding-block */
-		);
-	}
+    &:focus option:checked {
+      --force-bg-hack: linear-gradient(0deg, var(--accent) 0%, var(--accent) 100%);
+      background: var(--force-bg-hack);
+      color: var(--bg);
+    }
+  }
+  &:not([multiple], [size]) {
+    @supports (appearance: base-select) {
+      appearance: base-select;
+      field-sizing: fixed;  /* Someday this will size to widest option */
 
-	optgroup::before {
+      &::picker(select) {
+        appearance: base-select;
+        background: inherit;
+        border: inherit;
+        border-radius: inherit;
+      }
+
+      &::picker-icon {
+        --picker-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>');
+        background-color: currentColor;
+        mask-image: var(--picker-icon);
+        mask-repeat: no-repeat;
+        mask-position: center;
+        opacity: 0.7;
+      }
+      & option::checkmark {
+        display: none;
+      }
+    }
+  }
+
+	optgroup {
 		color: var(--muted-fg);
 		font-style: normal;
+    font-weight: bold;
+    &::before {
+      padding-inline-start: calc(var(--gap) / 4);
+    }
+    & > option {
+      padding-inline: var(--gap);
+    }
 	}
 
 	& option {
-		background: inherit;
-		color: inherit;
-		border: inherit;
-
+    &:checked:not(:hover, :focus-visible) {
+      background: var(--interactive-bg);
+      color: var(--bg);
+    }
 		&:hover {
-			/* This currently only applies to select[multiple] */
 			background: var(--accent);
-			color: var(--bg);
+			color: var(--box-bg);
 		}
-	}
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
 }
 
 meter, progress {

--- a/src/main.css
+++ b/src/main.css
@@ -847,7 +847,7 @@ select {
       background: var(--interactive-bg);
       color: var(--bg);
     }
-		&:hover {
+		&:is(:hover, :focus-visible) {
 			background: var(--accent);
 			color: var(--box-bg);
 		}

--- a/src/main.css
+++ b/src/main.css
@@ -164,6 +164,12 @@ footer {
 body > header,
 body > footer,
 main + footer {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+
 	padding: var(--rhythm, 1rlh) calc((100% - var(--eff-line-length)) / 2)
 }
 
@@ -279,6 +285,12 @@ figcaption {
 }
 
 main {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+
 	max-inline-size: var(--eff-line-length);
 	inline-size: 100%;
 	margin-inline: auto;
@@ -329,6 +341,17 @@ small[role="note"] {
 	clear: inline-end;
 
 	--sidenote-width: 20ch;
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+	--gutter-width: /* Width of spaces at each side of page content. */
+		calc(
+			(
+				var(--full-width)        /* Viewport width */
+				- var(--eff-line-length) /* minus line width */
+			) / 2);                    /* Divide by 2: there are two page margins */
 
 	max-inline-size: var(--sidenote-width);
 	padding-inline: 1.5ch 1ch;

--- a/src/utils.css
+++ b/src/utils.css
@@ -49,9 +49,14 @@
 .mono-font, .monospace { font-family: var(--mono-font) }
 
 .massivetext {
-    font-size: calc(.13 * var(--eff-line-length));
-	line-height: 1em;
-    letter-spacing: 0;
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+  font-size: calc(.13 * var(--eff-line-length));
+  line-height: 1em;
+  letter-spacing: 0;
 }
 
 .background-clip\:text {

--- a/src/variables.css
+++ b/src/variables.css
@@ -38,24 +38,24 @@
 	--line-length: 40rem; /* Maximum line length for prose. */
 
 	/* Borders */
-	--border-width: unset; /* Single value; set for uniform border widths */
-	--border-block-start-width: var(--border-width, 1px);
-	--border-block-end-width: var(--border-width, 1px);
-	--border-inline-start-width: var(--border-width, 1px);
-	--border-inline-end-width: var(--border-width, 1px);
-	--border-style: unset; /* Single value; set for uniform border styles */
-	--border-block-start-style: var(--border-style, solid);
-	--border-block-end-style: var(--border-style, solid);
-	--border-inline-start-style: var(--border-style, solid);
-	--border-inline-end-style: var(--border-style, solid);
+	--border-width: 1px; /* Single value; set for uniform border widths */
+	--border-block-start-width: var(--border-width);
+	--border-block-end-width: var(--border-width);
+	--border-inline-start-width: var(--border-width);
+	--border-inline-end-width: var(--border-width);
+	--border-style: solid; /* Single value; set for uniform border styles */
+	--border-block-start-style: var(--border-style);
+	--border-block-end-style: var(--border-style);
+	--border-inline-start-style: var(--border-style);
+	--border-inline-end-style: var(--border-style);
 	--border-radius: .2rem; /* Accepts multiple values, e.g. 1em 0 */
 
-	--interactive-border-width: var(--border-width, 1px); /* Single value */
-	--interactive-border-style: var(--border-style, solid); /* Single value */
+	--interactive-border-width: var(--border-width); /* Single value */
+	--interactive-border-style: var(--border-style); /* Single value */
 	--interactive-border-radius: .2rem; /* Single value */
 
-	--chip-border-width: var(--border-width, 1px); /* Single value */
-	--chip-border-style: var(--border-style, solid); /* Single value */
+	--chip-border-width: var(--border-width); /* Single value */
+	--chip-border-style: var(--border-style); /* Single value */
 
 	--tab-border-radius: .4em; /* Single value */
 

--- a/src/variables.css
+++ b/src/variables.css
@@ -83,20 +83,7 @@
 
 	/* Width */
 	--full-width: 100vw;
-
-	/* Do not set these. */
-	--eff-line-length: /* Effective line length for prose. */
-		min(
-			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
-			var(--line-length)
-		);
-
-	--gutter-width: /* Width of spaces at each side of page content. */
-		calc(
-			(
-				var(--full-width)        /* Viewport width */
-				- var(--eff-line-length) /* minus line width */
-			) / 2);                    /* Divide by 2: there are two page margins */
+  --sidebar-width: 25ch;
 }
 
 /* Respect the deprecated .-dark-theme and .-no-dark-theme classes */

--- a/www/docs/20-forms.md
+++ b/www/docs/20-forms.md
@@ -47,7 +47,7 @@ Input placeholders are styled with `text-align:end`{.language-css} to better dis
     <div>
       <label for=category>Category:</label>
       <select id=category placeholder="Select a category...">
-        <option>Blues</option>
+        <option>Blues
         <!-- ... -->
       </select>
     </div>
@@ -68,12 +68,12 @@ Input placeholders are styled with `text-align:end`{.language-css} to better dis
     <div>
       <label for=category>Category:</label>
       <select id=category placeholder="Select a category...">
-        <option>Blues</option>
-        <option>Dixieland</option>
-        <option>Swing</option>
-        <option>Bebop</option>
-        <option>Cool</option>
-        <option>Modal</option>
+        <option>Blues
+        <option>Dixieland
+        <option>Swing
+        <option>Bebop
+        <option>Cool
+        <option>Modal
       </select>
     </div>
     <div>
@@ -110,7 +110,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
     <thead>
       <tr><th><th><th><code>.info</code><th><code>.ok</code><th><code>.warn</code><th><code>.bad</code>
     <tbody>
-      <tr><th scope=row><code>&lt;button&gt;</code>
+      <tr><th scope=row><code>&lt;button></code>
           <td><button>Plain</button>
           <td><button class="ok">Open</button>
           <!-- ... -->
@@ -122,7 +122,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
           <td><button aria-pressed=true onclick="toggle(this)">Plain</button>
           <td><button aria-pressed=true class="ok" onclick="toggle(this)">Open</button>
           <!-- ... -->
-      <tr><th scope=row><code>&lt;strong&gt;&lt;button&gt;</code>
+      <tr><th scope=row><code>&lt;strong>&lt;button></code>
           <td><strong><button>Plain</button></strong>
           <td><strong><button class="ok">Open</button></strong>
           <!-- ... -->
@@ -134,7 +134,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
           <td><strong><button aria-pressed=true onclick="toggle(this)">Plain</button></strong>
           <td><strong><button aria-pressed=true class="ok" onclick="toggle(this)">Open</button></strong>
           <!-- ... -->
-      <tr><th scope=row><code>&lt;a class="&lt;button&gt;"&gt;</code>
+      <tr><th scope=row><code>&lt;a class="&lt;button>"></code>
           <td><a href=#button-table class="<button>">Plain</button>
           <td><a href=#button-table class="ok <button>">Open</button>
           <!-- ... -->
@@ -158,7 +158,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
     <thead>
       <tr><th><th><th><code>.info</code><th><code>.ok</code><th><code>.warn</code><th><code>.bad</code>
     <tbody>
-      <tr><th scope=row><code>&lt;button&gt;</code>
+      <tr><th scope=row><code>&lt;button></code>
           <td><button>Plain</button>
           <td><button class="info">Info</button>
           <td><button class="ok">Open</button>
@@ -176,7 +176,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
           <td><button aria-pressed=true class="ok" onclick="toggle(this)">Open</button>
           <td><button aria-pressed=true class="warn" onclick="toggle(this)">Reset</button>
           <td><button aria-pressed=true class="bad" onclick="toggle(this)">Close</button>
-      <tr><th scope=row><code>&lt;strong&gt;&lt;button&gt;</code>
+      <tr><th scope=row><code>&lt;strong>&lt;button></code>
           <td><strong><button>Plain</button></strong>
           <td><strong><button class="info">Info</button></strong>
           <td><strong><button class="ok">Open</button></strong>
@@ -194,7 +194,7 @@ Buttons, `.<button>` [masquerades][], and `<input type=file>`{.language-html} al
           <td><strong><button aria-pressed=true class="ok" onclick="toggle(this)">Open</button></strong>
           <td><strong><button aria-pressed=true class="warn" onclick="toggle(this)">Reset</button></strong>
           <td><strong><button aria-pressed=true class="bad" onclick="toggle(this)">Close</button></strong>
-      <tr><th scope=row><code>&lt;a class="&lt;button&gt;"&gt;</code>
+      <tr><th scope=row><code>&lt;a class="&lt;button>"></code>
           <td><a href=#button-table class="<button>">Plain</a></button>
           <td><a href=#button-table class="info <button>">Info</a></button>
           <td><a href=#button-table class="ok <button>">Open</a></button>
@@ -323,18 +323,36 @@ Missing.css will attempt to style `<select>`{.language-html} elements consistent
     <div>
     <label for=none>None:</label>
     <select id=none>
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+      <option>One
+      <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+      <option>Two
+      <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <!-- ... -->
     <div>
     <label for=bad>Bad:</label>
     <select id=bad class="bad">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
   </form>
@@ -345,9 +363,18 @@ Missing.css will attempt to style `<select>`{.language-html} elements consistent
     <!-- ... -->
     <label for=info>Info:
     <select id=info class="info color bg">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     <-- ... -->
   </form>
@@ -360,104 +387,302 @@ Missing.css will attempt to style `<select>`{.language-html} elements consistent
     <div>
     <label for=none>None:</label>
     <select id=none>
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
-    </select>
-    </div>
-    <div>
-    <label for=plain>Plain:</label>
-    <select id=plain class="plain">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=info>Info:</label>
     <select id=info class="info">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+     <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=ok>OK:</label>
     <select id=ok class="ok">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=warn>Warn:</label>
     <select id=warn class="warn">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=bad>Bad:</label>
     <select id=bad class="bad">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
+      <optgroup label="Scrollbar">
+        <option>Attempt
+        <option>to
+        <option>overflow
+        <option>the
+        <option>popover
+        <option>so
+        <option>that
+        <option>a
+        <option>wild
+        <option>scrollbar
+        <option>appears
     </select>
     </div>
   </form>
   <span class="aestheticbreak"></span>
   <form class="flex-switch">
-    <div>
-    <label for=none>None:</label>
-    <select id=none>
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
-    </select>
-    </div>
-    <div>
+  <div>
     <label for=plain>Plain:</label>
     <select id=plain class="plain bg color">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=info>Info:</label>
     <select id=info class="info bg color">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=ok>OK:</label>
     <select id=ok class="ok bg color">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=warn>Warn:</label>
     <select id=warn class="warn bg color">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
     </select>
     </div>
     <div>
     <label for=bad>Bad:</label>
     <select id=bad class="bad bg color">
-      <option>One</option>
-      <option>Two</option>
-      <option>Three</option>
+      <optgroup label="Odds">
+        <option>One
+        <option>Three
+        <option>Five
+        <option>Seven
+        <option>Nine
+      <optgroup label="Evens">
+        <option>Two
+        <option>Four
+        <option>Six
+        <option>Eight
+        <option>Ten
+      <optgroup label="Scrollbar">
+        <option>Attempt
+        <option>to
+        <option>overflow
+        <option>the
+        <option>popover
+        <option>so
+        <option>that
+        <option>a
+        <option>wild
+        <option>scrollbar
+        <option>appears
     </select>
     </div>
   </form>
 
+</figure>
+
+Selects with either `size`{ .token .attr-name } or `multiple`{.token .attr-name} attributes will be styled as listboxes.
+A listbox defined in this way is subject to HTML parsing rules and does not allow rich content.
+Keep in mind that `<option selected>`{.language-html} specifies which option(s) should be selected by default.
+If you are dynamically setting selection, you should use `option.checked = true`{.language-js},
+which triggers the proper `:checked`{.token .attr-name} pseudo-class.
+Do not dynamically use the `selected`{.token .attr-name} or `aria-selected=true`{.token .attr-name} attributes.
+
+By default, the width of the element will agree with the width of its longest `<option>`{.language-html};
+to override this, you can use the `.width:100%` utility class or set .e.g `<select size=4 style="width:20ch;">`{.language-html}.
+[Colorways][colorways] are supported.
+
+<figure>
+<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Select listboxes</figcaption>
+
+  ~~~ html
+  <div class="flex-switch">
+    <div>
+      <label for=select:single>Mathematicians:</label>
+      <select id=select:single size=8>
+        <optgroup label="Analysts">
+          <option>Stefan Banach
+          <option selected>Augustin-Louis Cauchy
+          <!-- ... -->
+      </select>
+      <p class="<small> crowded">Choose one</p>
+    </div>
+    <div>
+      <label for=select:multiple>Mathematicians:</label>
+      <select id=select:multiple size=8 multiple class="ok">
+        <optgroup label="Analysts">
+          <option>Stefan Banach
+          <option selected>Augustin-Louis Cauchy
+          <!-- ... -->
+      </select>
+      <p class="<small> crowded">Choose multiple</p>
+    </div>
+  </div>
+[browser support]: https://caniuse.com/mdn-css_properties_appearance_base-select
+[custom selects]: https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Customizable_select
+
+  ~~~
+
+  <hr>
+
+  <div class="flex-switch">
+    <div>
+      <label for=select:single>Mathematicians:</label>
+      <select id=select:single size=8>
+        <optgroup label="Analysts">
+          <option>Stefan Banach
+          <option selected>Augustin-Louis Cauchy
+          <option>Leonhard Euler
+          <option>Joseph Fourier
+          <option>David Hilbert
+          <option>Karl Weierstrass
+        <optgroup label="Algebrists">
+          <option>Niels Abel
+          <option>Arthur Cayley
+          <option>Évariste Galois
+          <option>Sophus Lie
+          <option>Emmy Noether
+        <optgroup label="Topologists">
+          <option>Felix Hausdorff
+          <option>Felix Klein
+          <option>August Möbius
+          <option>Henri Poincaré
+          <option>Bernhard Riemann
+          <option>Andrei Tychonoff
+      </select>
+      <p class="<small> crowded">Choose one</p>
+    </div>
+    <div>
+      <label for=select:multiple>Mathematicians:</label>
+      <select id=select:multiple size=8 multiple class="ok">
+        <optgroup label="Analysts">
+          <option>Stefan Banach
+          <option selected>Augustin-Louis Cauchy
+          <option>Leonhard Euler
+          <option>Joseph Fourier
+          <option>David Hilbert
+          <option selected>Karl Weierstrass
+        <optgroup label="Algebrists">
+          <option>Niels Abel
+          <option>Arthur Cayley
+          <option selected>Évariste Galois
+          <option>Sophus Lie
+          <option>Emmy Noether
+        <optgroup label="Topologists">
+          <option>Felix Hausdorff
+          <option>Felix Klein
+          <option>August Möbius
+          <option>Henri Poincaré
+          <option>Bernhard Riemann
+          <option>Andrei Tychonoff
+      </select>
+      <p class="<small> crowded">Choose multiple</p>
+    </div>
+  </div>
 </figure>
 
 
@@ -474,7 +699,7 @@ The element can be styled by setting `--border-width`, `--border-style`, and `--
 When not explicitly set, the element inherits from `--interactive-border-width`, `--interactive-border-style`, and `--tab-border-radius`.
 
 For full-width progress bars, use the `.width:100%` utility class.
-[Colorways](colorways) are supported.
+[Colorways][colorways] are supported.
 
 
 <figure>

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -171,6 +171,7 @@ Alternatively, you can use `role=toolbar`{.token .attr-name}.
 
 Use the <dfn>`.sidebar-layout`</dfn> class to create a sidebar/main layout.
 Put sidebar content in a `<header>`{.language-html} element directly inside `.sidebar-layout`{.language-css}, and the next element will house the rest of the page.
+The width of the sidebar can be set using the `--sidebar-width` variable.
 See this example:
 
 <figure>

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -117,6 +117,7 @@ these are grouped together at the bottom, in addition to being mentioned in the 
 :   Maximum line length for prose.
 
 
+
 ## Borders
    
 <dfn>`--border-width`</dfn> {#var-border-width}
@@ -255,6 +256,10 @@ these are grouped together at the bottom, in addition to being mentioned in the 
 <dfn>`--col-width`</dfn> {#var-col-width}
 :   Sets the width of a column for `.textcolumns`.
     Default is `30ch`{.token .attr-value}.
+
+<dfn>`--sidebar-width`</dfn> {#var-sidebar-width}
+:   Sets the width of the sidebar for the `.sidebar-layout` component.
+    Default is `25ch`{.token .attr-value}.
 
 <dfn>`--grid-row-width`</dfn> {#var-grid-row-width}
 :   Sets the width of a row in a `.grid`.

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -222,7 +222,7 @@ The <dfn>`.big`</dfn> class will be removed in version 2.0.
  
   <div class="flex-row align-items:center">
     <button class="<big> bad">Big Bad Button</button>
-    <a class="bad <button>" href=#>&lt;a&gt; Bad Button</a>
+    <a class="bad <button>" href=#>&lt;a> Bad Button</a>
   </div>
   
   <aside class="<big>">
@@ -237,7 +237,7 @@ The <dfn>`.big`</dfn> class will be removed in version 2.0.
  
   <div class="flex-row align-items:center">
     <button class="<big> bad">Big Bad Button</button>
-    <a class="bad <button>" href=#>&lt;a&gt; Bad Button</a>
+    <a class="bad <button>" href=#>&lt;a> Bad Button</a>
   </div>
   
   <aside class="<big>">


### PR DESCRIPTION
This untangles the web of `select[multiple][size]` and `appearance: base-select`. Tested in Firefox and Chrome Canary, I'm pretty happy with it and would consider it appropriate to close #91 after this gets merged.

I think `<select size|multiple>` should be styled similar to the upcoming listbox component. To that end, one thing that I'm a little iffy on is what `option:checked:not(:hover, :focus-visible)` should look like. I copped the current styling from the old listbox impl, and it looks good when `<select>` is being used as a "native listbox." However, that style does (currently) bleed over to the dropdown picker (when `appearance: base-select` is supported, e.g. Chrome), and from what I can tell most UI impls of the dropdown picker have no styles on `option:checked` when it's not hovered/focused.

This also inherently fixes some bugs in 1.2.0: 
- `<select multiple>` had a fixed height of lineheight+padding, resulting in broken listbox
- `select option` had `border: inherit`, which resulted in an ugly listbox.

Thoughts?