### PR TITLE
Fix Sidenotes

### DIFF
--- a/src/components.css
+++ b/src/components.css
@@ -286,3 +286,79 @@ details,
     padding-inline: 0;
   }
 }
+
+small[role="note"] {
+  /***
+   Sidenote
+   ***/
+  display: block;
+
+  --sidenote-width: 20ch;
+  --eff-line-length: /* Effective line length for prose. */
+    min(
+      calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+      var(--line-length)
+    );
+  --gutter-width: /* Width of spaces at each side of page content. */
+    calc(
+      (
+        var(--full-width)        /* Viewport width */
+        - var(--eff-line-length) /* minus line width */
+      ) / 2);                    /* Divide by 2: there are two page margins */
+  --translate:
+    calc(
+      var(--sidenote-width)
+      - min(
+        var(--gutter-width) - 1em - 1ch,
+        var(--sidenote-width)
+      )
+    );
+
+
+  max-inline-size: var(--sidenote-width);
+  padding-block: 1ch;
+  padding-inline: 1.5ch 1ch;
+
+  font-family: var(--secondary-font);
+
+  background: var(--bg);
+
+  border-block-start: var(--border-block-start-width) var(--border-block-start-style) transparent;
+  border-block-end: var(--border-block-end-width) var(--border-block-end-style) transparent;
+  border-inline-start: var(--border-inline-start-width) var(--border-inline-start-style) transparent;
+  border-inline-end: var(--border-inline-end-width) var(--border-inline-end-style) transparent;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: transform .1s ease-in-out;
+  }
+
+  /* default to float:right */
+  float: inline-end;
+  clear: inline-end;
+  margin-inline: 0 calc(-1 * var(--sidenote-width) - 1ch);
+  --translate-x: calc(-1 * var(--translate));
+
+  &.float\:left {
+    float: inline-start;
+    clear: inline-start;
+    margin-inline: calc(-1 * var(--sidenote-width) - 1ch) 0;
+    --translate-x: var(--translate);
+  }
+
+  &:hover, &:focus-within {
+    border-color: var(--graphical-fg);
+    border-radius: var(--border-radius);
+    background: var(--box-bg);
+    transform: translateX(var(--translate-x));
+  }
+
+  @media (max-width: 768px) {
+    --translate-x: 0;
+    margin-inline: 1em 0;
+
+    &.float\:left {
+      --translate-x: 0;
+      margin-inline: 0 1em;
+    }
+  }
+}

--- a/src/components.css
+++ b/src/components.css
@@ -291,29 +291,20 @@ small[role="note"] {
   /***
    Sidenote
    ***/
-  display: block;
-
+  --full-width: 100vi;
   --sidenote-width: 20ch;
-  --eff-line-length: /* Effective line length for prose. */
-    min(
-      calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
-      var(--line-length)
-    );
-  --gutter-width: /* Width of spaces at each side of page content. */
-    calc(
-      (
-        var(--full-width)        /* Viewport width */
-        - var(--eff-line-length) /* minus line width */
-      ) / 2);                    /* Divide by 2: there are two page margins */
-  --translate:
-    calc(
-      var(--sidenote-width)
-      - min(
-        var(--gutter-width) - 1em - 1ch,
-        var(--sidenote-width)
-      )
-    );
+  --gutter-width: max(
+    var(--rhythm, 1rlh),                          /* gutter min */
+    (var(--full-width) - var(--line-length)) / 2  /* gutter max */
+  );
+  --margin-inline: calc(
+    0px - min(
+      var(--gutter-width) - 1em,
+      var(--sidenote-width) + 1em
+    ) + 1em - 1ch
+  );
 
+  display: block;
 
   max-inline-size: var(--sidenote-width);
   padding-block: 1ch;
@@ -328,37 +319,22 @@ small[role="note"] {
   border-inline-start: var(--border-inline-start-width) var(--border-inline-start-style) transparent;
   border-inline-end: var(--border-inline-end-width) var(--border-inline-end-style) transparent;
 
-  @media (prefers-reduced-motion: no-preference) {
-    transition: transform .1s ease-in-out;
-  }
-
-  /* default to float:right */
-  float: inline-end;
-  clear: inline-end;
-  margin-inline: 0 calc(-1 * var(--sidenote-width) - 1ch);
-  --translate-x: calc(-1 * var(--translate));
-
-  &.float\:left {
-    float: inline-start;
-    clear: inline-start;
-    margin-inline: calc(-1 * var(--sidenote-width) - 1ch) 0;
-    --translate-x: var(--translate);
-  }
-
   &:hover, &:focus-within {
     border-color: var(--graphical-fg);
     border-radius: var(--border-radius);
     background: var(--box-bg);
-    transform: translateX(var(--translate-x));
   }
 
-  @media (max-width: 768px) {
-    --translate-x: 0;
-    margin-inline: 1em 0;
+  /* default to inline-end side */
+  float: inline-end;
+  clear: inline-end;
+  margin-inline: 1ch var(--margin-inline);
 
-    &.float\:left {
-      --translate-x: 0;
-      margin-inline: 0 1em;
-    }
+  /* flip to inline-start side */
+  &.flip {
+    float: inline-start;
+    clear: inline-start;
+    margin-inline: var(--margin-inline) 1ch;
   }
+
 }

--- a/src/components.css
+++ b/src/components.css
@@ -330,12 +330,14 @@ small[role="note"] {
   float: inline-end;
   clear: inline-end;
   margin-inline: 1ch var(--margin-inline);
+  text-align: start;
 
   /* flip to inline-start side */
   &.flip {
     float: inline-start;
     clear: inline-start;
     margin-inline: var(--margin-inline) 1ch;
+    text-align: end;
   }
 
 }

--- a/src/components.css
+++ b/src/components.css
@@ -7,7 +7,8 @@
 figure,
 details,
 :where(dialog) {
-    margin: var(--gap) 0;
+    margin-block: var(--gap);
+    margin-inline: 0;
     padding: var(--gap);
     overflow: clip;
 

--- a/src/main.css
+++ b/src/main.css
@@ -199,7 +199,8 @@ pre {
 	line-height: var(--rhythm, 1rlh);
 	tab-size: 2;
 
-	margin: var(--gap) 0;
+	margin-block: var(--gap);
+  margin-inline: 0;
 
 	overflow-x: auto;
 }
@@ -283,7 +284,7 @@ main {
 	inline-size: 100%;
 	margin-inline: auto;
 
-	&:first-child { padding-top: var(--gap); }
+	&:first-child { padding-block-start: var(--gap); }
 }
 
 /***
@@ -941,8 +942,9 @@ label[for] {
 fieldset {
 	position: relative;
 
-    padding: var(--gap);
-	margin: var(--gap) 0;
+  padding: var(--gap);
+	margin-block: var(--gap);
+  margin-inline: 0;
 	width: 100%;
 	border-radius: var(--border-radius);
 
@@ -967,9 +969,8 @@ details:not(specificity-hack) {
 }
 
 summary {
-	margin: calc(0px - var(--gap));
-	margin-top: calc(0px - var(--gap));
-	margin-bottom: 0;
+	margin-inline: calc(0px - var(--gap));
+	margin-block: calc(0px - var(--gap)) 0;
 	padding-inline: var(--gap);
 
 	font-family: var(--secondary-font);

--- a/src/main.css
+++ b/src/main.css
@@ -320,42 +320,6 @@ a, .\<a\> {
 	}
 }
 
-small[role="note"] {
-	/***
-	 Sidenote
-	 ***/
-	display: block;
-	float: inline-end;
-	clear: inline-end;
-
-	--sidenote-width: 20ch;
-
-	max-inline-size: var(--sidenote-width);
-	padding-inline: 1.5ch 1ch;
-
-	margin-inline-end: calc(1em - var(--sidenote-width));
-	margin-block-end: var(--rhythm, 1rlh);
-
-	font-family: var(--secondary-font);
-
-	background: var(--bg);
-	border-block-start: var(--border-block-start-width) var(--border-block-start-style) transparent;
-	border-block-end: var(--border-block-end-width) var(--border-block-end-style) transparent;
-	border-inline-start: var(--border-inline-start-width) var(--border-inline-start-style) transparent;
-	border-inline-end: var(--border-inline-end-width) var(--border-inline-end-style) transparent;
-
-	transition: transform .1s ease-in-out;
-
-	&:hover, &:focus-within {
-		border-color: var(--graphical-fg);
-		border-radius: var(--border-radius);
-		transform: translateX(calc(
-			0px - var(--sidenote-width)
-			+ min(var(--gutter-width), var(--sidenote-width))
-		))
-	}
-}
-
 small, .\<small\> {
 	font-size: .8em;
 	line-height: calc(var(--rhythm, 1rlh) * 2 / 3);

--- a/www/demos/sidenotes.md
+++ b/www/demos/sidenotes.md
@@ -2,30 +2,32 @@
 title: Sidenotes
 ---
 
-Sidenotes are created with the `<small role=note tabindex=0>`{ .language-html } element.
+Sidenotes are created with the `<small role=note>`{ .language-html } element.
 Sidenotes are supplemental notes or comments placed in the margins of a page, typically alongside the main text.
 They provide additional information, context, or commentary related to the adjacent text.
 
 The width of a sidenote is set using the `--sidenote-width` variable (which defaults to `20ch`).
-Sidenotes will be clipped by the width of the page's margins and revealed during hover or focus events.
 On smaller screens, the notes will be floated inside the main text.
 
-Sidenotes must be visually and semantically distinct even when the viewport isn't wide enough to facilitate their normal placement.
+By default, sidenotes will be placed in the `inline-end`{.token .attr-name} side on larger screens and floated to `inline-end`{.token .attr-name} on small screens.
+Sidenotes will respect both the `[dir=rtl|ltr]`{.token .attr-name} attribute and `writing-mode`{.token .attr-name} CSS property.
+To switch sides apply the `.flip` class.
+
 This page has a few sidenotes which are implemented using markup similar to the example below.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Sidenote markup</figcaption>
 
 ~~~ html
-<small role=note tabindex=0>
+<small role=note>
 	This is the first sidenote.
-	Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
-	The default value for `--sidenote-width` is `20ch`.
+	By default it will float to the the inline-end side.
+	The default value for <code>--sidenote-width</code> is <code>20ch</code>.
 </small>
-<small role=note tabindex=0 class="ok bg color" style="--sidenote-width:40ch;">
+<small role=note class="ok bg color flip" style="--sidenote-width:40ch;">
 	This is the second sidenote.
-	On large screens, it appears in the left-hand margin because the XYZ attribute is set.
-	Since I wanted to change the width of the sidenote, I set the `--sidenote-width` variable to 40ch.
+	It will float to the inline-start side due to the <code>.flip</code> class.
+	Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to <code>40ch</code>.
 </small>
 ~~~
 
@@ -34,10 +36,10 @@ This page has a few sidenotes which are implemented using markup similar to the 
 What follows now is some <i>lorem ipsum</i> so that we can demonstrate the sidenotes.
 You can adjust the viewport width in order to see how the sidenotes will display on mobile screens.
 
-<small role=note tabindex=0>
+<small role=note>
 This is the first sidenote.
-Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
-The default value for `--sidenote-width` is `20ch`.
+By default it will float to the the inline-end side.
+The default value for <code>--sidenote-width</code> is <code>20ch</code>.
 </small>
 
 The Dude abides.
@@ -60,10 +62,10 @@ You don't have to do that, you know.
 I had a rough night and I hate the Eagles.
 What in God's name are you blathering about?
 
-<small role=note tabindex=0 class="float:left ok bg color" style="--sidenote-width: 40ch;">
+<small role=note class="ok bg color flip" style="--sidenote-width:40ch;">
 This is the second sidenote.
-On large screens, it appears in the left-hand margin because it has the <code>.float:left</code> class.
-Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to 40ch.
+It will float to the inline-start side due to the <code>.flip</code> class.
+Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to <code>40ch</code>.
 </small>
 
 I am the Walrus.

--- a/www/demos/sidenotes.md
+++ b/www/demos/sidenotes.md
@@ -1,25 +1,28 @@
 ---
-draft: true
 title: Sidenotes
 ---
 
-Sidenotes are created with the `<small role=note>`{ .language-html } element.
+Sidenotes are created with the `<small role=note tabindex=0>`{ .language-html } element.
 Sidenotes are supplemental notes or comments placed in the margins of a page, typically alongside the main text.
 They provide additional information, context, or commentary related to the adjacent text.
+
+The width of a sidenote is set using the `--sidenote-width` variable (which defaults to `20ch`).
+Sidenotes will be clipped by the width of the page's margins and revealed during hover or focus events.
+On smaller screens, the notes will be floated inside the main text.
 
 Sidenotes must be visually and semantically distinct even when the viewport isn't wide enough to facilitate their normal placement.
 This page has a few sidenotes which are implemented using markup similar to the example below.
 
 <figure>
-<figcaption><sub-title class=allcaps>Example</sub-title>Sidenotes</figcaption>
+<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Sidenote markup</figcaption>
 
 ~~~ html
-<small role=note>
+<small role=note tabindex=0>
 	This is the first sidenote.
 	Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
 	The default value for `--sidenote-width` is `20ch`.
 </small>
-<small role=note style="--sidenote-width:40ch;">
+<small role=note tabindex=0 class="ok bg color" style="--sidenote-width:40ch;">
 	This is the second sidenote.
 	On large screens, it appears in the left-hand margin because the XYZ attribute is set.
 	Since I wanted to change the width of the sidenote, I set the `--sidenote-width` variable to 40ch.
@@ -31,7 +34,7 @@ This page has a few sidenotes which are implemented using markup similar to the 
 What follows now is some <i>lorem ipsum</i> so that we can demonstrate the sidenotes.
 You can adjust the viewport width in order to see how the sidenotes will display on mobile screens.
 
-<small role=note>
+<small role=note tabindex=0>
 This is the first sidenote.
 Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
 The default value for `--sidenote-width` is `20ch`.
@@ -45,12 +48,6 @@ This is not 'Nam, this is bowling; there are rules.
 Careful, man, there's a beverage here.
 That's just, like, your opinion, man.
 
-<small role=note class="float:left" style="--sidenote-width: 40ch;">
-This is the second sidenote.
-On large screens, it appears in the left-hand margin because it has the <code>.float:left</code> class.
-Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to 40ch.
-</small>
-
 My thinking about this case, which has been, like, a lot of ins and outs, a lot of what-have-yous.
 The bums will always lose.
 Obviously you're not a golfer.
@@ -62,6 +59,12 @@ You want a toe? I can get you a toe, believe me. There are ways, Dude.
 You don't have to do that, you know.
 I had a rough night and I hate the Eagles.
 What in God's name are you blathering about?
+
+<small role=note tabindex=0 class="float:left ok bg color" style="--sidenote-width: 40ch;">
+This is the second sidenote.
+On large screens, it appears in the left-hand margin because it has the <code>.float:left</code> class.
+Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to 40ch.
+</small>
 
 I am the Walrus.
 Or was it, Karl Hungus?

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -445,5 +445,34 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
 </figure>
 
+## Sidenotes
+
+Sidenotes are created with the `<small role=note tabindex=0>`{ .language-html } element.
+Sidenotes are supplemental notes or comments placed in the margins of a page, typically alongside the main text.
+They provide additional information, context, or commentary related to the adjacent text.
+
+The width of a sidenote is set using the `--sidenote-width` variable (which defaults to `20ch`).
+Sidenotes will be clipped by the width of the page's margins and revealed during hover or focus events.
+On smaller screens, the notes will be floated inside the main text.
+
+<figure>
+<figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Sidenote markup</figcaption>
+
+~~~ html
+<small role=note tabindex=0>
+	This is the first sidenote.
+	Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
+	The default value for `--sidenote-width` is `20ch`.
+</small>
+<small role=note tabindex=0 class="ok bg color" style="--sidenote-width:40ch;">
+	This is the second sidenote.
+	On large screens, it appears in the left-hand margin because the XYZ attribute is set.
+	Since I wanted to change the width of the sidenote, I set the `--sidenote-width` variable to 40ch.
+</small>
+~~~
+
+**<a href=/demos/sidenotes class="<button>">Sidenote demo &rarr;</a>**
+</figure>
+
 
 [colorway]: /docs/colorways

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -181,8 +181,8 @@ See this example:
     <header>
       <ul role="list">
         <li><a href=/>Home</a></li>
-        <li><a href=/>Profile</a></li>
-        <li><a href=/>Settings</a></li>
+        <li><a href=/profile>Profile</a></li>
+        <li><a href=/settings>Settings</a></li>
         <!-- ... -->
       </ul>
     </header>
@@ -214,11 +214,11 @@ The separator will be set to either `--breadcrumb-page` or `--breadcrumb-step` d
   ~~~ html
   <nav class="breadcrumbs" aria-label="Breadcrumbs">
     <ol>
-      <li><a href=#>Home</a></li>
-      <li><a href=#>User</a></li>
-      <li><a href=#>Advanced</a></li>
-      <li><a href=#>New All</a></li>
-      <li><a href=# aria-current=page>Quit Sibelius</a></li>
+      <li><a href=/>Home</a></li>
+      <li><a href=/user>User</a></li>
+      <li><a href=/advanced>Advanced</a></li>
+      <li><a href=/new>New All</a></li>
+      <li><a href=/quit aria-current=page>Quit Sibelius</a></li>
     </ol>
   </nav>
   ~~~
@@ -246,8 +246,8 @@ If you want to preserve the `<ol>`{.language-html} numbering, use the `type`{.to
     <strong class="<h1>">Checkout</strong>
     <nav class="breadcrumbs" aria-label="Breadcrumbs">
       <ol type=1>
-        <li><a href=#>Cart</a></li>
-        <li><a href=# aria-current=step>Account</a></li>
+        <li><a href=/cart>Cart</a></li>
+        <li><a href=/account aria-current=step>Account</a></li>
         <li>Info</li>
         <li>Payment</li>
         <li>Review</li>
@@ -309,10 +309,10 @@ example:
   <header class="navbar">
     <nav aria-label="Site sections">
       <ul role="list">
-        <li><a href=/><img alt="missing.js" src="/logo.png"></a>
+        <li><a href=#><img alt="missing.js" src="/logo.png"></a>
         <li><a href=/docs>Docs</a>
-        <li><a href=/docs>Contribute</a>
-        <li><a href=/docs>Donate</a>
+        <li><a href=/contribute>Contribute</a>
+        <li><a href=/donate>Donate</a>
       </ul>
     </nav>
     <nav aria-label="Social media links">

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -447,32 +447,34 @@ We recommend using <a href=https://lucide.dev>Lucide</a> for icons.
 
 ## Sidenotes
 
-Sidenotes are created with the `<small role=note tabindex=0>`{ .language-html } element.
+Sidenotes are created with the `<small role=note>`{ .language-html } element.
 Sidenotes are supplemental notes or comments placed in the margins of a page, typically alongside the main text.
 They provide additional information, context, or commentary related to the adjacent text.
 
 The width of a sidenote is set using the `--sidenote-width` variable (which defaults to `20ch`).
-Sidenotes will be clipped by the width of the page's margins and revealed during hover or focus events.
 On smaller screens, the notes will be floated inside the main text.
+
+By default, sidenotes will be placed in the `inline-end`{.token .attr-name} side on larger screens and floated to `inline-end`{.token .attr-name} on small screens.
+Sidenotes will respect both the `[dir=rtl|ltr]`{.token .attr-name} attribute and `writing-mode`{.token .attr-name} CSS property.
+To switch sides apply the `.flip` class.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Sidenote markup</figcaption>
 
 ~~~ html
-<small role=note tabindex=0>
+<small role=note>
 	This is the first sidenote.
-	Be default it will appear in the right-hand margin, provided the margin is larger than `--sidenote-width`.
-	The default value for `--sidenote-width` is `20ch`.
+	By default it will float to the the inline-end side.
+	The default value for <code>--sidenote-width</code> is <code>20ch</code>.
 </small>
-<small role=note tabindex=0 class="ok bg color" style="--sidenote-width:40ch;">
+<small role=note class="ok bg color flip" style="--sidenote-width:40ch;">
 	This is the second sidenote.
-	On large screens, it appears in the left-hand margin because the XYZ attribute is set.
-	Since I wanted to change the width of the sidenote, I set the `--sidenote-width` variable to 40ch.
+	It will float to the inline-start side due to the <code>.flip</code> class.
+	Since I wanted to change the width of the sidenote, I set the <code>--sidenote-width</code> variable to <code>40ch</code>.
 </small>
 ~~~
 
 **<a href=/demos/sidenotes class="<button>">Sidenote demo &rarr;</a>**
 </figure>
-
 
 [colorway]: /docs/colorways

--- a/www/docs/60-variables.md
+++ b/www/docs/60-variables.md
@@ -264,10 +264,12 @@ these are grouped together at the bottom, in addition to being mentioned in the 
 :   Sets the width of a column in a `.grid`.
     Default is `1fr`{.token .attr-value}.
 
-<!--
+<dfn>`--sidebar-width`</dfn> {#var-sidebar-width}
+:   Sets the width of the sidebar for the `.sidebar-layout` component.
+    Default is `25ch`{.token .attr-value}.
+
 <dfn>`--sidenote-width`</dfn> {#var-sidenote-width}
 :   Sets the width of a `<small role=note>`{.language-html} sidenote.
     Default is `20ch`{.token .attr-value}.
--->
 
 [colorway]: /docs/colorways


### PR DESCRIPTION
Fix for the long un-documented sidenotes component.

 - We should probably use a custom attribute instead of `.float:left` class, we'll brainstorm that at the meeting.
   - **A: Use the new `.flip` utility class** 