### PR TITLE
Close #154

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -5,24 +5,27 @@
 }
 
 [role="tab"]:not([specificity-hack]) {
-    all: initial;
-    color-scheme: light dark;
+    /* button-specific resets */
+    font-size: 1em;
+	  line-height: var(--rhythm, 1.4rem);
+    border: none;
+    box-shadow: none;
+    &:is(:hover, :focus-visible, :active, :disabled) {
+      filter: none;
+      box-shadow: none;
+    }
 
-	font-family: var(--secondary-font);
-    
-    padding: 0 calc(var(--rhythm, 1rlh) / 4);
+    /* tab styles */
     margin: 0;
-    min-height: var(--rhythm, 1rlh);
-    bottom: calc(-1 * var(--border-block-start-width));
     position: relative;
-    
-    color: var(--fg);
+    inset-block-end: calc(-1 * var(--border-block-start-width));
+
     border: var(--border-block-start-width) var(--border-block-start-style) var(--graphical-fg);
-    background: var(--interactive-bg);
-    
     border-start-start-radius: var(--tab-border-radius);
     border-start-end-radius: var(--tab-border-radius);
-    
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
+
     &:active, &[aria-selected="true"] {
         background: var(--box-bg);
         border-block-end: var(--border-block-start-width) var(--border-block-start-style) transparent;
@@ -30,14 +33,13 @@
 
     &:hover {
         background-color: var(--box-bg);
-        box-shadow: none;
     }
 
     &:focus-visible {
-        box-shadow: none;
         color: var(--accent);
         text-decoration: underline;
     }
+
 }
 
 [role="tabpanel"] {
@@ -55,15 +57,18 @@
 
     z-index: 10;
     
-    padding: calc(var(--gap) / 2) 0;
-    margin: 1px 0 0 0;
+    padding-block: calc(var(--gap) / 2)
+    padding-inline: 0;
+    margin-block: 1px 0;
+    margin-inline: 0;
 
     display: flex;
     flex-flow: column nowrap;
 }
 
 [role=menuitem] {
-    padding: 0 calc(var(--gap) / 2);
+    padding-block: 0;
+    padding-inline: calc(var(--gap) / 2);
 
     display: block;
 
@@ -115,7 +120,7 @@
 
 [aria-orientation="vertical"] {
     flex-direction: column;
-    width: fit-content;
+    inline-size: fit-content;
     text-align: center;
 }
 
@@ -127,6 +132,23 @@ input[type=checkbox][role=switch] {
   --toggle-nub-margin: 2px;
   --toggle-nub-background: var(--graphical-fg);
 
+  --toggle-translate-end: translateX(
+    calc(100% + 2 * var(--toggle-nub-margin))
+  );
+  --toggle-translate-mid: translateX(
+    calc(50% + var(--toggle-nub-margin))
+  );
+
+  .writing-mode\:vertical-lr &,
+  .writing-mode\:vertical-rl & {
+    --toggle-translate-end: translateY(
+      calc(100% + 2 * var(--toggle-nub-margin))
+    );
+    --toggle-translate-mid: translateY(
+      calc(50% + var(--toggle-nub-margin))
+    );
+  }
+
   all: unset;
   appearance: none;
 
@@ -135,6 +157,7 @@ input[type=checkbox][role=switch] {
   grid-template-columns: repeat(2, 1rem);
 
   aspect-ratio: 2 / 1;
+  block-size: 1em;
   margin-block: auto;
   isolation: isolate;
 
@@ -142,7 +165,10 @@ input[type=checkbox][role=switch] {
     content: '';
     display: inline-block;
 
-    transition: transform .2s ease-in-out, background-color .2s ease-in-out, background-color .2s ease-in-out;
+    transition:
+      transform .2s ease-in-out,
+      translate .2s ease-in-out,
+      background-color .2s ease-in-out;
   }
 
   &::before {
@@ -167,7 +193,7 @@ input[type=checkbox][role=switch] {
     --toggle-track-background: var(--accent);
     --toggle-nub-background: var(--bg);
     &::after {
-      transform: translateX(calc(100% + 2 * var(--toggle-nub-margin)));
+      transform: var(--toggle-translate-end);
     }
   }
 
@@ -175,7 +201,7 @@ input[type=checkbox][role=switch] {
     --toggle-track-border-color: var(--interactive-bg);
     --toggle-nub-background: var(--interactive-bg);
     &::after {
-      transform: translateX(calc(50% + var(--toggle-nub-margin)));
+      transform: var(--toggle-translate-mid);
     }
   }
 
@@ -201,7 +227,7 @@ input[type=checkbox][role=switch] {
   }
   :is(label:has(+ &)) {
     /* Lightning CSS requires :is() when nested selector doesn't start with & */
-    width: 100%;
+    inline-size: 100%;
   }
 
 }

--- a/src/components.css
+++ b/src/components.css
@@ -7,7 +7,8 @@
 figure,
 details,
 :where(dialog) {
-    margin: var(--gap) 0;
+    margin-block: var(--gap);
+    margin-inline: 0;
     padding: var(--gap);
     overflow: clip;
 

--- a/src/components.css
+++ b/src/components.css
@@ -77,7 +77,17 @@ details,
 }
 
 .sidebar-layout {
+  --border:
+    var(--border-inline-end-width)
+    var(--border-inline-end-style)
+    var(--graphical-fg);
+
 	& header {
+    border-inline: none;
+    border-block: none;
+    border-block-end: var(--border);
+    border-radius: 0;
+
 		& li {
 			margin-block: calc(.5 * var(--gap));
 		}
@@ -87,14 +97,41 @@ details,
 		}
 	}
 
+  .writing-mode\:vertical-lr &,
+  .writing-mode\:vertical-rl & {
+    /* Vertical writing modes should not have the < 75ch width layout */
+    /* Just duplicate the styles from the media query for now */
+    display: grid;
+    grid-template-columns: var(--sidebar-width) auto;
+    inset: 0;
+
+		display: grid;
+		grid-template-columns: var(--sidebar-width) auto;
+		inset: 0;
+
+		& > header {
+			border-block-end: none;
+			border-inline-end: var(--border);
+			margin: 0;
+		}
+
+		& > :nth-child(2) {
+			overflow: auto;
+      scrollbar-width: auto;
+			--full-width: calc(100vi - var(--sidebar-width));
+			padding-block-start: var(--gap);
+		}
+
+  }
+
 	@media (min-width: 75ch) {
 		display: grid;
 		grid-template-columns: var(--sidebar-width) auto;
 		inset: 0;
 
 		& > header {
-			border-block: none;
-			border-inline-start: none;
+			border-block-end: none;
+			border-inline-end: var(--border);
 			margin: 0;
 		}
 

--- a/src/components.css
+++ b/src/components.css
@@ -88,7 +88,7 @@ details,
 
 	@media (min-width: 75ch) {
 		display: grid;
-		grid-template-columns: 25ch auto;
+		grid-template-columns: var(--sidebar-width) auto;
 		inset: 0;
 
 		& > header {
@@ -100,8 +100,8 @@ details,
 		& > :nth-child(2) {
 			overflow: auto;
       scrollbar-width: auto;
-			--full-width: calc(100vw - 25ch);
-			padding-top: var(--gap);
+			--full-width: calc(100vi - var(--sidebar-width));
+			padding-block-start: var(--gap);
 		}
 	}
 }
@@ -155,12 +155,11 @@ details,
 	border-block-end: var(--border-block-end-width) var(--border-block-end-style) var(--accent);
 
 	overflow-x: auto;
+	z-index: 5;
 
 	position: sticky;
-	z-index: 5;
-	top: 0;
-	left: 0;
-	right: 0;
+  inset-block-start: 0;
+	inset-inline: 0;
 
 	/* Inner layout */
 	display: flex;
@@ -172,7 +171,7 @@ details,
 		flex-flow: column;
 		align-items: start;
 
-		max-height: 90vh;
+		max-block-size: 90svb;
 		overflow-y: auto;
 
 		& ul[role="list"] { flex-flow: column; }
@@ -217,21 +216,22 @@ details,
 	}
 
 	& [aria-current=page]::after {
-		width: 100%;
-		height: 6px;
 		content: "";
 		display: block;
 		position: absolute;
-		bottom: calc(-1 * var(--gap));
 		background: currentcolor;
+
+		block-size: 6px;
+		inline-size: 100%;
+		inset-block-end: calc(-1 * var(--gap));
+    inset-inline: 0;
 	}
 
 	&.expanded [aria-current=page]::after {
-		width: 6px;
-		height: 100%;
-		position: absolute;
-		left: calc(-1 * var(--gap));
-		top: 0;
+		block-size: 100%;
+		inline-size: 6px;
+		inset-inline-start: calc(-1 * var(--gap));
+		inset-block: 0;
 	}
 }
 
@@ -251,8 +251,8 @@ details,
 	box-shadow: none;
 	line-height: var(--rhythm, 1rlh);
 	font-size: 24px;  /* WCAG target size AA */
-	width: 24px;
-	height: 24px;
+	inline-size: 24px;
+	block-size: 24px;
 	text-align: center;
 	border-radius: 50%;
 	transition: font-weight .2s ease-in-out;
@@ -281,8 +281,8 @@ details,
   &:is(.big, .\<big\>) {
     /* WCAG target size AAA */
     font-size: 44px;
-    width: 44px;
-    height: 44px;
+    inline-size: 44px;
+    block-size: 44px;
     padding-inline: 0;
   }
 }

--- a/src/layout.css
+++ b/src/layout.css
@@ -1,3 +1,8 @@
+/**/
+
+.writing-mode\:vertical-lr { writing-mode:vertical-lr }
+.writing-mode\:vertical-rl { writing-mode:vertical-rl }
+
 .textcolumns {
   --col-width: 30ch;
 
@@ -29,8 +34,6 @@
   }
 }
 
-
-
 .text-align\:center {
     text-align: center;
 }
@@ -45,6 +48,11 @@
 /**/
 
 .container {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
 	max-inline-size: var(--eff-line-length);
 	margin-inline: auto;
 }
@@ -62,9 +70,8 @@
 }
 
 .fullscreen {
-    height: 100vh;
-
     position: relative;
+    height: 100vh;
     width: 100vw;
     left: 50%;
     transform: translateX(-50vw);
@@ -73,8 +80,10 @@
     border-inline: none;
 }
 
-.width\:100\%  { width:100%;  max-width: 100%  }
-.height\:100\% { height:100%; max-height: 100% }
+.width\:100\%  { width:  100%; max-width:  100% }
+.height\:100\% { height: 100%; max-height: 100% }
+.inline-size\:100\% { inline-size: 100%; max-inline-size: 100% }
+.block-size\:100\%  { block-size:  100%; max-block-size:  100% }
 
 /**/
 
@@ -192,7 +201,7 @@
 
 .flow-gap {
     & > :not(:last-child) {
-        margin-bottom: var(--gap);
+        margin-block-end: var(--gap);
     }
 }
 
@@ -204,7 +213,7 @@
 
 .table {
     display: table;
-    width: 100%;
+    inline-size: 100%;
     margin: 0;
 }
 
@@ -212,7 +221,7 @@
     display: table-row;
 
     &:not(:last-child):not([specificity-hack]) > * {
-        margin-bottom: var(--gap);
+        margin-block-end: var(--gap);
     }
 
     & > *:not([specificity-hack]) {
@@ -246,9 +255,17 @@
 .right  { right:  0 }
 .bottom { bottom: 0 }
 .left   { left:   0 }
+.inset-block-start  { inset-block-start:  0 }
+.inset-block-end    { inset-block-end:    0 }
+.inset-inline-start { inset-inline-start: 0 }
+.inset-inline-end   { inset-inline-end:   0 }
+.inset-block        { inset-block:  0 }
+.inset-inline       { inset-inline: 0 }
 
 .float\:left  { float: left  }
 .float\:right { float: right }
+.float\:inline-start { float: inline-start }
+.float\:inline-end   { float: inline-end   }
 
 .overflow\:auto     { overflow: auto;     }
 .overflow\:scroll   { overflow: scroll;   }
@@ -275,7 +292,7 @@
 
   main, .container {
     max-inline-size: unset;
-    width: auto;
+    inline-size: auto;
   }
 
   h1, h2, h3, h4, h5, h6,

--- a/src/layout.css
+++ b/src/layout.css
@@ -57,27 +57,26 @@
 	margin-inline: auto;
 }
 
-.fullbleed:not([specificity-hack]) {
-    /* NOTE: Specificity hack needed for e.g. <table class="fullbleed table"> */
+.fullbleed,
+.fullscreen {
     position: relative;
-    max-width: none;
-    width: var(--full-width);
-    left: 50%;
-    transform: translateX(calc(-.5 * var(--full-width)));
+    max-inline-size: none;
+    inline-size: var(--full-width);
+    inset-inline-start: 50%;
+
+    transform: translateX(calc(-0.5 * var(--full-width)));
+    .writing-mode\:vertical-lr &,
+    .writing-mode\:vertical-rl & {
+      transform: translateY(calc(-0.5 * var(--full-width)));
+    }
 
     border-radius: 0;
     border-inline: none;
 }
 
 .fullscreen {
-    position: relative;
-    height: 100vh;
-    width: 100vw;
-    left: 50%;
-    transform: translateX(-50vw);
-
-    border-radius: 0;
-    border-inline: none;
+    max-block-size: none;
+    block-size: 100dvb;
 }
 
 .width\:100\%  { width:  100%; max-width:  100% }

--- a/src/main.css
+++ b/src/main.css
@@ -170,7 +170,7 @@ main + footer {
 			var(--line-length)
 		);
 	padding-block: var(--rhythm, 1rlh);
-  padding-inline: calc((100% - var(--eff-line-length)) / 2);
+  padding-inline: calc((var(--full-width) - var(--eff-line-length)) / 2);
 }
 
 address {

--- a/src/main.css
+++ b/src/main.css
@@ -205,7 +205,8 @@ pre {
 	line-height: var(--rhythm, 1rlh);
 	tab-size: 2;
 
-	margin: var(--gap) 0;
+	margin-block: var(--gap);
+  margin-inline: 0;
 
 	overflow-x: auto;
 }
@@ -293,7 +294,7 @@ main {
 	inline-size: 100%;
 	margin-inline: auto;
 
-	&:first-child { padding-top: var(--gap); }
+	&:first-child { padding-block-start: var(--gap); }
 }
 
 /***

--- a/src/main.css
+++ b/src/main.css
@@ -142,9 +142,9 @@ h6:target {
 		content: "";
 		display: block;
 		position: absolute;
-		left: -.5em;
-		width: 4px;
-		height: 100%;
+		inset-inline-start: -.5em;
+		inline-size: 4px;
+		block-size: 100%;
 		background: var(--accent);
 	}
 }
@@ -164,7 +164,13 @@ footer {
 body > header,
 body > footer,
 main + footer {
-	padding: var(--rhythm, 1rlh) calc((100% - var(--eff-line-length)) / 2)
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
+	padding-block: var(--rhythm, 1rlh);
+  padding-inline: calc((100% - var(--eff-line-length)) / 2);
 }
 
 address {
@@ -221,7 +227,6 @@ blockquote {
 	}
 
 	& footer {
-		text-align: right;
 		text-align: end;
 	}
 }
@@ -265,7 +270,7 @@ dl {
 }
 
 figure {
-	max-width: 100%;
+	max-inline-size: 100%;
 	margin-inline: 0;
 
     /* SEE components/box.css */
@@ -279,6 +284,11 @@ figcaption {
 }
 
 main {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
 	max-inline-size: var(--eff-line-length);
 	inline-size: 100%;
 	margin-inline: auto;
@@ -400,7 +410,8 @@ kbd kbd /*
 */ {
 	display: inline-block;
 
-	padding: 0 .3em;
+	padding-block: 0
+  padding-inline: .3em;
 	font-size: .8em;
 	line-height: 1.1em;
 
@@ -518,14 +529,15 @@ label :is(input, select):not([specificity-hack]) {
 ):not(.\<a\>) {
   /* Any changes made here must also be made to ::file-selector-button below */
 	display: inline-block;
-	padding: 0 calc(var(--rhythm, 1rlh) / 4);
+	padding-block: 0;
+  padding-inline: calc(var(--rhythm, 1rlh) / 4);
 	vertical-align: middle;
 	box-sizing: border-box;
 
 	font-size: .8rem;
 	line-height: 1.125em;
 	font-family: var(--secondary-font);
-	min-height: var(--rhythm, 1rlh);
+	min-block-size: var(--rhythm, 1rlh);
 
 	background: var(--interactive-bg);
 	color: var(--fg);
@@ -647,14 +659,15 @@ input::file-selector-button {
    * we have to duplicate styles from above. */
 
 	display: inline-block;
-	padding: 0 calc(var(--rhythm, 1rlh) / 4);
+	padding-block: 0;
+  padding-inline: calc(var(--rhythm, 1rlh) / 4);
 	vertical-align: middle;
 	box-sizing: border-box;
 
 	font-size: .8rem;
 	line-height: 1.125em;
 	font-family: var(--secondary-font);
-	min-height: var(--rhythm, 1rlh);
+	min-block-size: var(--rhythm, 1rlh);
 
 	background: var(--interactive-bg);
 	color: var(--fg);
@@ -748,21 +761,22 @@ textarea {
 }
 
 input[type="range"] {
-	width: 100%;
+	inline-size: 100%;
 	padding: calc(var(--gap) / 4);
 }
 
 input[type="color"] {
 	padding: 0;
 	margin: 0;
-	height: calc(1.5 * var(--rhythm, 1rlh));
+	block-size: calc(1.5 * var(--rhythm, 1rlh));
 
 	border: none;
 	background: none;
 }
 
 input[type="file"] {
-	padding: calc(var(--gap) / 4) 0;
+	padding-block: calc(var(--gap) / 4);
+  padding-inline: 0;
 	font: inherit;
 	line-height: calc(var(--rhythm, 1rlh) / 2);
 	&::file-selector-button {
@@ -921,17 +935,31 @@ progress {
   }
   &:not([value]) {
     /* Indeterminate state */
-    --track-bg-color: linear-gradient(to right,
+    --track-animation: progress-indeterminate 4s infinite ease-in-out;
+
+    --track-size: 225% 100%;
+    --track-animation-direction: to right;
+    --track-bg-position-start: right;
+    --track-bg-position-end: left;
+    .writing-mode\:vertical-lr &,
+    .writing-mode\:vertical-rl & {
+      --track-size: 100% 225%;
+      --track-animation-direction: to bottom;
+      --track-bg-position-start: bottom;
+      --track-bg-position-end: top;
+    }
+
+    --track-bg-color: linear-gradient(
+      var(--track-animation-direction),
       var(--box-bg) 45%,
       var(--accent) 0%,
       var(--accent) 55%,
       var(--box-bg) 0%
     );
-    --track-size: 225% 100%;
-    --track-bg-position: right;
-    --track-animation: progress-loading 4s infinite ease-in-out;
+
     @media (prefers-reduced-motion) {
-      --track-bg-position: center;
+      --track-bg-position-start: center;
+      --track-bg-position-end: center;
       --track-animation: none;
     }
 
@@ -943,7 +971,7 @@ progress {
         position: absolute;
         background: var(--track-bg-color);
         background-size: var(--track-size);
-        background-position: var(--track-bg-position);
+        background-position: var(--track-bg-position-start);
         animation: var(--track-animation);
       }
     }
@@ -951,7 +979,7 @@ progress {
       &::-webkit-progress-bar {
         background: var(--track-bg-color);
         background-size: var(--track-size);
-        background-position: var(--track-bg-position);
+        background-position: var(--track-bg-position-start);
         animation: var(--track-animation);
       }
     }
@@ -959,14 +987,14 @@ progress {
       &::-moz-progress-bar {
         background: var(--track-bg-color);
         background-size: var(--track-size);
-        background-position: var(--track-bg-position);
+        background-position: var(--track-bg-position-start);
         animation: var(--track-animation);
       }
     }
   }
 }
-@keyframes progress-loading {
-  50% { background-position: left; }
+@keyframes progress-indeterminate {
+  50% { background-position: var(--track-bg-end) }
 }
 
 label[for] {
@@ -977,9 +1005,10 @@ label[for] {
 fieldset {
 	position: relative;
 
-    padding: var(--gap);
-	margin: var(--gap) 0;
-	width: 100%;
+  padding: var(--gap);
+	margin-block: var(--gap);
+  margin-inline: 0;
+	inline-size: 100%;
 	border-radius: var(--border-radius);
 
 	& > legend + * { margin-block-start: 0 }

--- a/src/utils.css
+++ b/src/utils.css
@@ -49,6 +49,11 @@
 .mono-font, .monospace { font-family: var(--mono-font) }
 
 .massivetext {
+	--eff-line-length: /* Effective line length for prose. */
+		min(
+			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
+			var(--line-length)
+		);
     font-size: calc(.13 * var(--eff-line-length));
 	line-height: 1em;
     letter-spacing: 0;
@@ -73,7 +78,7 @@
     display: block;
     margin: 0;
     padding: 0;
-    height: calc(.5 * var(--gap));
+    block-size: calc(.5 * var(--gap));
 }
 
 @media screen {

--- a/src/variables.css
+++ b/src/variables.css
@@ -82,21 +82,8 @@
 	--density: 1;
 
 	/* Width */
-	--full-width: 100vw;
-
-	/* Do not set these. */
-	--eff-line-length: /* Effective line length for prose. */
-		min(
-			calc( var(--full-width) - (2 * var(--rhythm, 1rlh)) ),
-			var(--line-length)
-		);
-
-	--gutter-width: /* Width of spaces at each side of page content. */
-		calc(
-			(
-				var(--full-width)        /* Viewport width */
-				- var(--eff-line-length) /* minus line width */
-			) / 2);                    /* Divide by 2: there are two page margins */
+	--full-width: 100vi;
+  --sidebar-width: 25ch;
 }
 
 /* Respect the deprecated .-dark-theme and .-no-dark-theme classes */

--- a/www/_build/markdown.ts
+++ b/www/_build/markdown.ts
@@ -17,7 +17,7 @@ export default {
       permalink: mdAnchor.permalink.linkInsideHeader({
         placement: "before",
         symbol: "§",
-        class: "permalink-anchor float:right",
+        class: "permalink-anchor float:inline-end",
       }),
       level: 2,
     }],

--- a/www/demos/apg/landmarks.md
+++ b/www/demos/apg/landmarks.md
@@ -26,7 +26,7 @@ Missing.css relies on the implicit landmark roles for HTML sectioning elements.
 | Form          | `<form>`{ .language-html }                        |
 | Region        | `<section aria-label=required>`{ .language-html } |
 
-{ .width:100% }
+{ .inline-size:100% }
 
 The `<header>`{ .language-html } and `<footer>`{ .language-html } elements are only given landmark roles when they are direct descendants of the `<body>`{ .language-html } element.
 Note that in order for a `<section>`{ .language-html } element to be an implicit landmark role, it must be given a valid `aria-label`{ .token .attr-name } or `aria-labelledby`{ .token .attr-name } attribute.

--- a/www/demos/apg/table.md
+++ b/www/demos/apg/table.md
@@ -15,7 +15,7 @@ apg:
 
 ## Notes
 
-Missing.css uses the `<table>`{ .language-html } element for tables; for full-width tables, use the `.width:100%` utility class.
+Missing.css uses the `<table>`{ .language-html } element for tables; for full-width tables, use the `.inline-size:100%` utility class.
 ["Pseudo-tables"][] can be created from other elements by applying the `.table` and `.rows` classes.
 
 ["Pseudo-tables"]: /docs/layout/#pseudo-tables
@@ -26,7 +26,7 @@ Missing.css uses the `<table>`{ .language-html } element for tables; for full-wi
 ## Example
 
 <figure>
-	<table class="width:100%">
+	<table class="inline-size:100%">
 		<caption>
 			Front-end web developer course 2021
 		</caption>

--- a/www/demos/sidebar.html
+++ b/www/demos/sidebar.html
@@ -21,8 +21,8 @@ hideFooter: yes
 			<li><a href=#>Signed in as jdoe@example.com</a>
 			<li><a href=#>Sign out</a>
 			<li><a href=#>DevTools</a>
-			<li><strong><a href=/docs/components/#sidebar class="<button> width:100%">&larr; missing.css docs</a></strong>
-			<li><strong><a href=/demos class="<button> width:100%">&larr; missing.css demos</a></strong>
+			<li><strong><a href=/docs/components/#sidebar class="<button> inline-size:100%">&larr; missing.css docs</a></strong>
+			<li><strong><a href=/demos class="<button> inline-size:100%">&larr; missing.css demos</a></strong>
 			</ul>
 		</nav>
 	</header>

--- a/www/docs/20-forms.md
+++ b/www/docs/20-forms.md
@@ -476,6 +476,8 @@ When not explicitly set, the element inherits from `--interactive-border-width`,
 For full-width progress bars, use the `.inline-size:100%` utility class.
 [Colorways](colorways) are supported.
 
+When used with vertical writing modes, the indeterminate state requires a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
+
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Progress bar markup</figcaption>

--- a/www/docs/20-forms.md
+++ b/www/docs/20-forms.md
@@ -473,7 +473,7 @@ Indeterminate `<progress>`{.language-html} elements will show a pending animatio
 The element can be styled by setting `--border-width`, `--border-style`, and `--border-radius` variables directly on the `<progress>`{.language-html} element.
 When not explicitly set, the element inherits from `--interactive-border-width`, `--interactive-border-style`, and `--tab-border-radius`.
 
-For full-width progress bars, use the `.width:100%` utility class.
+For full-width progress bars, use the `.inline-size:100%` utility class.
 [Colorways](colorways) are supported.
 
 
@@ -484,16 +484,16 @@ For full-width progress bars, use the `.width:100%` utility class.
   <div class="flex-column">
      
     <label for=p1 class="vh">Upload progress...</label>
-    <progress id=p1 value=0.5 class="width:100%"></progress>
+    <progress id=p1 value=0.5 class="inline-size:100%"></progress>
 
     <label for=p2>LCARS Scan...</label>
-    <progress id=p2 class="ok width:100%" value=0.25 style="height: 1.5em; --border-width: 6px; --border-style: double; --border-radius: 0 .5em"></progress>
+    <progress id=p2 class="ok inline-size:100%" value=0.25 style="block-size: 1.5em; --border-width: 6px; --border-style: double; --border-radius: 0 .5em"></progress>
 
     <label for=p3>Virus progress...</label>
-    <progress id=p3 class="warn width:100%" value=0.75 style="--border-width: 3px; --border-style: inset; --border-radius: 0 .5rem .5rem .5rem"></progress>
+    <progress id=p3 class="warn inline-size:100%" value=0.75 style="--border-width: 3px; --border-style: inset; --border-radius: 0 .5rem .5rem .5rem"></progress>
 
     <label for=p4>Indeterminate Cylon</label>
-    <progress id=p4 class="bad" style="width: 3em;">Indeterminate Cylon</progress>
+    <progress id=p4 class="bad" style="inline-size: 3em;">Indeterminate Cylon</progress>
 
   </div>
   ~~~
@@ -503,16 +503,16 @@ For full-width progress bars, use the `.width:100%` utility class.
   <div class="flex-column">
 
     <label for=p1 class="vh">Upload progress...</label>
-    <progress id=p1 value=0.5 class="width:100%"></progress>
+    <progress id=p1 value=0.5 class="inline-size:100%"></progress>
 
     <label for=p2>LCARS Scan...</label>
-    <progress id=p2 class="ok width:100%" value=0.25 style="height: 1.5em; --border-width: 6px; --border-style: double; --border-radius: 0 .5em"></progress>
+    <progress id=p2 class="ok inline-size:100%" value=0.25 style="block-size: 1.5em; --border-width: 6px; --border-style: double; --border-radius: 0 .5em"></progress>
 
     <label for=p3>Virus progress...</label>
-    <progress id=p3 class="warn width:100%" value=0.75 style="--border-width: 3px; --border-style: inset; --border-radius: 0 .5rem .5rem .5rem"></progress>
+    <progress id=p3 class="warn inline-size:100%" value=0.75 style="--border-width: 3px; --border-style: inset; --border-radius: 0 .5rem .5rem .5rem"></progress>
 
     <label for=p4>Indeterminate Cylon</label>
-    <progress id=p4 class="bad" style="width: 3em;">Indeterminate Cylon</progress>
+    <progress id=p4 class="bad" style="inline-size: 3em;">Indeterminate Cylon</progress>
 
   </div>
 

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -118,7 +118,7 @@ Missing.css provides this as the <dfn>`.permalink-anchor`</dfn> class.
 
   ~~~ html
   <h2 id=section-permalinks class="packed" tabindex=-1>
-    <a class="permalink-anchor float:right" href=#section-permalinks>§</a>
+    <a class="permalink-anchor float:inline-end" href=#section-permalinks>§</a>
     Section permalinks
   </h2>
   ~~~
@@ -126,7 +126,7 @@ Missing.css provides this as the <dfn>`.permalink-anchor`</dfn> class.
   <hr>
 
   <h2 id=section-permalinks tabindex=-1 class="packed">
-    <a href=#section-permalinks class="permalink-anchor float:right">§</a>
+    <a href=#section-permalinks class="permalink-anchor float:inline-end">§</a>
     Section permalinks
   </h2>
 

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -239,7 +239,7 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
 Use <dfn>`[role=switch]`{.token .attr-value}</dfn> with `<input type=checkbox>`{.language-html}.
 
 The indeterminate state is supported, but it must be set with JavaScript.
-Vertical writing modes are supported, but there must be a parent element with `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
+When used with vertical writing modes, toggle switches require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Toggle switch markup</figcaption>

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -55,8 +55,7 @@ To get the actual behavior of an accessible tabset, you can use [Missing.js &sec
       >Channels</button>
     <button role=tab aria-controls=users
       >Users</button>
-  </div>
-  
+  </div> 
   <div id=servers         role=tabpanel>This is tab 1. <strong>JavaScript sold separately!</strong></div>
   <div id=channels hidden role=tabpanel>You are enjoying tab 2.</div>
   <div id=users    hidden role=tabpanel><img alt="placeholder cat" src=https://biber.denizaksimsek.com/img/IMG_2022-07-05_07-16-48-400.webp></div>
@@ -237,8 +236,10 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
 
 ## Toggle Switch
 
-Use `switch`{.token .attr-value} role with `<input type=checkbox>`{.language-html}.
+Use <dfn>`[role=switch]`{.token .attr-value}</dfn> with `<input type=checkbox>`{.language-html}.
+
 The indeterminate state is supported, but it must be set with JavaScript.
+Vertical writing modes are supported, but there must be a parent element with `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Toggle switch markup</figcaption>

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -125,7 +125,8 @@ Add the <dfn>`.fullbleed`</dfn> class to make an element go outside its containe
 
 The <dfn>`.fullscreen`</dfn> class will size an element to fill the screen.
 
-When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set. These classes will not work on flex children (e.g. children of `.flex-row`, `.flex-column`, or `.flex-switch` containers).
+When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
+These classes will not work on flex children (e.g. children of `.flex-row`, `.flex-column`, or `.flex-switch` containers).
 
 
 ## Layout utilities

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -15,6 +15,19 @@ Mechanisms of creating layouts.
 </details>
 
 
+## Writing Modes
+
+Use the <dfn>`.writing-mode:vertical-lr`</dfn> and <dfn>`.writing-mode:vertical-rl`</dfn> classes to enable vertical layouts.
+
+While missing.css prioritizes logical properties, a few components still rely on physical property values (like `transform()`{.language-css}) and require the writing mode classes in order to orient correctly:
+
+ - The `.fullbleed` and `.fullscreen` layout utilities,
+ - The `[role=switch]` input toggle, and
+ - `<progress>`{.language-html} bars (specifically the "indeterminate" animation when `@prefers-reduced-motion()`{.language-css} is not set).
+
+If you aren't using these specific components, missing.css will handle vertical writing-mode natively without the need for extra classes (assuming the author sets `writing-mode` somewhere in their css).
+
+
 ## Centering
 
 <dfn>`.text-align:center`</dfn> center-aligns text.
@@ -111,6 +124,8 @@ Add the <dfn>`.fullbleed`</dfn> class to make an element go outside its containe
 
 The <dfn>`.fullscreen`</dfn> class will size an element to fill the screen.
 
+When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
+
 
 ## Layout utilities
 
@@ -175,6 +190,7 @@ To remove padding or margin, use one of the following classes:
 
 Make an element full-width with the <dfn>`.width:100%`</dfn> class.
 Similarly with <dfn>`.height:100%`</dfn>.
+Logical variants <dfn>`.inline-size:100%`</dfn> and <dfn>`.block-size:100%`</dfn> are also available.
 
 [density utilities]: /docs/utils/#density
 
@@ -272,8 +288,7 @@ To set the aspect ratio of an element, use the `aspect-ratio`{.token .attr-name}
 <figure>
 
   ~~~html
-  <style>#aspect-ratio-example > .box { height: 10vh }</style>
-  <div id="aspect-ratio-example" class="flex-row flex-wrap:wrap">
+  <div id=aspect-ratio-example class="flex-row align-items:center overflow:auto">
     <div class="box" style="aspect-ratio: 1/1">1:1</div>
     <div class="box" style="aspect-ratio: 4/3">4:3</div>
     <div class="box" style="aspect-ratio: 16/9">16:9</div>
@@ -285,8 +300,7 @@ To set the aspect ratio of an element, use the `aspect-ratio`{.token .attr-name}
   </div>
   ~~~
 
-  <style>#aspect-ratio-example > .box { height: 10vh }</style>
-  <div id="aspect-ratio-example" class="flex-row flex-wrap:wrap">
+  <div id=aspect-ratio-example class="flex-row align-items:center overflow:auto">
     <div class="box" style="aspect-ratio: 1/1">1:1</div>
     <div class="box" style="aspect-ratio: 4/3">4:3</div>
     <div class="box" style="aspect-ratio: 16/9">16:9</div>
@@ -358,7 +372,7 @@ Pseudo-tables work nicely with description lists:
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Pseudo-table markup for description lists</figcaption>
 
   ~~~ html
-  <dl class="table rows" style="width: auto;">
+  <dl class="table rows" style="inline-size: auto;">
     <div><dt>Name:     <dd>Anakin Skywalker</div>
     <div><dt>Alias:    <dd>Darth Vader     </div>
     <div><dt>Species:  <dd>Human           </div>
@@ -370,7 +384,7 @@ Pseudo-tables work nicely with description lists:
 
   <hr>
 
-  <dl class="table rows" style="width: auto;">
+  <dl class="table rows" style="inline-size: auto;">
     <div><dt>Name:     <dd>Anakin Skywalker</div>
     <div><dt>Alias:    <dd>Darth Vader     </div>
     <div><dt>Species:  <dd>Human           </div>
@@ -415,11 +429,41 @@ Pseudo-tables work nicely with description lists:
 :   Set `left: 0`.
     See `.top`.
 
+<dfn>`.inset-block-start`</dfn>
+:   Set `inset-block-start: 0`.
+    Use together with `.fixed` or `.sticky`.
+
+<dfn>`.inset-inline-end`</dfn>
+:   Set `inside-inline-end: 0`.
+    Use together with `.fixed` or `.sticky`.
+
+<dfn>`.inset-block-end`</dfn>
+:   Set `inset-block-end: 0`.
+    Use together with `.fixed` or `.sticky`.
+
+<dfn>`.inset-inline-start`</dfn>
+:   Set `inset-inline-start: 0`.
+    Use together with `.fixed` or `.sticky`.
+
+<dfn>`.inset-block`</dfn>
+:   Set `inset-block: 0`.
+    Use together with `.fixed` or `.sticky`.
+
+<dfn>`.inset-inline`</dfn>
+:   Set `inset-inline: 0`.
+    Use together with `.fixed` or `.sticky`.
+
 <dfn>`.float:left`</dfn>
 :   Set `float: left`.
 
 <dfn>`.float:right`</dfn>
 :   Set `float: right`.
+
+<dfn>`.float:inline-start`</dfn>
+:   Set `float: inline-start`.
+
+<dfn>`.float:inline-end`</dfn>
+:   Set `float: inline-end`.
 
 ## Printing
 

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -124,7 +124,7 @@ Add the <dfn>`.fullbleed`</dfn> class to make an element go outside its containe
 
 The <dfn>`.fullscreen`</dfn> class will size an element to fill the screen.
 
-When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
+When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set. These classes will not work on flex children (e.g. children of `.flex-row`, `.flex-column`, or `.flex-switch` containers).
 
 
 ## Layout utilities

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -18,6 +18,7 @@ Mechanisms of creating layouts.
 ## Writing Modes
 
 Use the <dfn>`.writing-mode:vertical-lr`</dfn> and <dfn>`.writing-mode:vertical-rl`</dfn> classes to enable vertical layouts.
+If used, we recommended placing them on the `<html>`{.language-html} element for best results.
 
 While missing.css prioritizes logical properties, a few components still rely on physical property values (like `transform()`{.language-css}) and require the writing mode classes in order to orient correctly:
 

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -27,7 +27,7 @@ Other uses include providing instructions for interactive elements or detailed d
 ## Container
 
 <dfn>`.container`</dfn>
-:   Imposes a maximum width on an element and centers it.
+:   Imposes a maximum width (`inline-size`) on an element and centers it.
 
 The `<main>`{.language-html} element does the same, but carries semantic baggage that might not be appropriate for all contexts.
 
@@ -48,7 +48,7 @@ We provide the following utility classes that set `--density`:
 | <dfn>`.airy`</dfn>        | `--density` = 3                            |
 | <dfn>`.autodensity`</dfn> | sets density based on viewport width       |
 
-{ .width:100% }
+{ .inline-size:100% }
 
 You can also use the following classes to set density on child elements while maintaining a separate density for the containing element:
 

--- a/www/pages/index.md
+++ b/www/pages/index.md
@@ -8,7 +8,7 @@ templateEngine: [vento, md]
 
 <h1 class="flex-row crowded">
   <img src="/img/logo/missing-logo.svg"
-    style="width: 1.5lh; aspect-ratio: 1/1;">
+    style="inline-size: 1.5lh; aspect-ratio: 1/1;">
   <span class="flex-column packed">
     <span class=allcaps>missing<wbr>.css<v-h>:</v-h></span> <sub-title>The Missing CSS Stylesheet</sub-title>
   </span>


### PR DESCRIPTION
Went through and changed all physical properties / values to logical ones (where possible). Other than adding a few utility classes, this shouldn't introduce any "breaking" changes (although it does fix many bugs in vertical writing modes, including button spacing, tabs, margins, toggle buttons, progress bars, etc).

Questions:

- [x] Add `.inset-inline|block-start|end` and `.inset-inline|block` utility classes or nah? (they're currently implemented)
  - **A: Yes, but we wish the names were a little less verbose**
- [x] Is support okay for `svb|dvi|vb|vi` units okay?
  - **A: According to [caniuse](https://caniuse.com/mdn-css_types_length_viewport_percentage_units_dynamic) looks like we're good, since we don't particularly support UC Browser, Opera Mini, KaiOS or Baidu.**
- [x] What to do about `vertical-align`?
  - Can be pushed down the road imo
  - Really only an issue for values of `top|bottom`. 
  - **A: Push down the road, there's some nuances where the property is set on elements that by default don't support the value, but this might play into `.table.rows`, etc.**
- [x] What to do about `@media(min-width)` queries? (same)
  - `.autodensity` based on min-width **A: Keep as is**
  - `.grid` based on min|max-width **A: Keep as is**
  - `.sidebar-layout` has a @media(min-width: 75ch) **A: Fix to remove the non-media query alignment on vertical writing-modes. 
- [x] Are the current implementations of `.fullbleed` and  `.fullscreen` sufficient for vertical writing modes without changing anything?
  - **A: Nope, they will rely on `.writing-mode:vertical-lr|rl` because of `.sidebar-layout`.**
