### PR TITLE
Remove .writing-mode util classes

### DIFF
--- a/src/aria.css
+++ b/src/aria.css
@@ -131,15 +131,20 @@ input[type=checkbox][role=switch] {
   --toggle-nub-margin: 2px;
   --toggle-nub-background: var(--graphical-fg);
 
+
+  /* Hack until logical translate comes out */
+  &:dir(ltr) { --dir:  1 }
+  &:dir(rtl) { --dir: -1 }
+
   --toggle-translate-end: translateX(
-    calc(100% + 2 * var(--toggle-nub-margin))
+    calc(var(--dir) * (100% + 2 * var(--toggle-nub-margin)))
   );
   --toggle-translate-mid: translateX(
-    calc(50% + var(--toggle-nub-margin))
+    calc(var(--dir) * (50% + var(--toggle-nub-margin)))
   );
 
-  .writing-mode\:vertical-lr &,
-  .writing-mode\:vertical-rl & {
+  &.vertical {
+    /* Hack until :writing-mode() comes out */
     --toggle-translate-end: translateY(
       calc(100% + 2 * var(--toggle-nub-margin))
     );

--- a/src/layout.css
+++ b/src/layout.css
@@ -3,9 +3,6 @@
  Typography
 ***/
 
-.writing-mode\:vertical-lr { writing-mode:vertical-lr }
-.writing-mode\:vertical-rl { writing-mode:vertical-rl }
-
 .textcolumns {
   --col-width: 30ch;
 

--- a/src/layout.css
+++ b/src/layout.css
@@ -70,16 +70,15 @@
 
 .fullbleed,
 .fullscreen {
+  --gutter-width: calc(
+    (var(--full-width) - var(--eff-line-length)) / 2
+  );
+
   position: relative;
   max-inline-size: none;
   inline-size: var(--full-width);
-  inset-inline-start: 50%;
+  margin-inline-start: calc(0px - var(--gutter-width));
 
-  transform: translateX(calc(-0.5 * var(--full-width)));
-  .writing-mode\:vertical-lr &,
-  .writing-mode\:vertical-rl & {
-    transform: translateY(calc(-0.5 * var(--full-width)));
-  }
 
   border-radius: 0;
   border-inline: none;

--- a/src/main.css
+++ b/src/main.css
@@ -492,7 +492,7 @@ label :is(input, select):not([specificity-hack]) {
   .\<button\>
 ):not(.\<a\>) {
   /* Any changes made here must also be made to ::file-selector-button below */
-  display: inline-block;
+  display: inline-flex;
   padding-block: 0;
   padding-inline: calc(var(--rhythm, 1rlh) / 4);
   vertical-align: middle;
@@ -513,7 +513,6 @@ label :is(input, select):not([specificity-hack]) {
     /* a-specific resets */
     color: var(--fg);
     text-decoration: none;
-    display: inline-flex;  /* TODO: Above we have display: inline-block */
     justify-content: center;
     align-items: center;
     cursor: default;
@@ -625,7 +624,7 @@ input::file-selector-button {
    We have to duplicate styles from above.
   **/
 
-  display: inline-block;
+  display: inline-flex;
   padding-block: 0;
   padding-inline: calc(var(--rhythm, 1rlh) / 4);
   vertical-align: middle;

--- a/src/main.css
+++ b/src/main.css
@@ -1080,8 +1080,8 @@ progress {
     --track-animation-direction: to right;
     --track-bg-position-start: right;
     --track-bg-position-end: left;
-    .writing-mode\:vertical-lr &,
-    .writing-mode\:vertical-rl & {
+    &.vertical {
+      /* Opt-in animation fix until :writing-mode() is supported */
       --track-size: 100% 225%;
       --track-animation-direction: to bottom;
       --track-bg-position-start: bottom;

--- a/www/docs/20-forms.md
+++ b/www/docs/20-forms.md
@@ -326,7 +326,7 @@ Depending on the attributes specified, `<select>`{.language-html} elements can b
 
 - single-select dropdowns,
 - single-select listboxes,
-- sulti-select listboxes, and
+- multi-select listboxes, and
 - multi-select dropdowns.
 
 Checkmarks can be enabled by using the `.checks` or `.checkboxes` variant classes on the `<select>`{.language-html} (provided the viewer's browser supports them).

--- a/www/docs/20-forms.md
+++ b/www/docs/20-forms.md
@@ -908,14 +908,13 @@ Be sure to add a `<label>`{.language-html} for accessibility (in conjunction wit
 
 The element can be put in an indeterminate state by not including the `value`{.token .attr-name} attribute.
 Indeterminate `<progress>`{.language-html} elements will show a pending animation if the user does not have `@prefers-reduced-motion`{.language-css} set.
+When utilizing a vertical writing-mode, the indeterminate animation can be fixed by adding the `.vertical`{.language-css} class.
 
 The element can be styled by setting `--border-width`, `--border-style`, and `--border-radius` variables directly on the `<progress>`{.language-html} element.
 When not explicitly set, the element inherits from `--interactive-border-width`, `--interactive-border-style`, and `--tab-border-radius`.
 
 For full-width progress bars, use the `.inline-size:100%` utility class.
 [Colorways][] are supported.
-
-When used with vertical writing modes, the indeterminate state requires a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
 
 
 <figure>

--- a/www/docs/30-components.md
+++ b/www/docs/30-components.md
@@ -458,7 +458,6 @@ The width of a sidenote is set using the `--sidenote-width` variable (which defa
 On smaller screens, the notes will be floated inside the main text.
 
 By default, sidenotes will be placed in the `inline-end`{.token .attr-name} side on larger screens and floated to `inline-end`{.token .attr-name} on small screens.
-Sidenotes will respect both the `[dir=rtl|ltr]`{.token .attr-name} attribute and `writing-mode`{.token .attr-name} CSS property.
 To switch sides apply the `.flip` class.
 
 <figure>

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -240,6 +240,9 @@ Use <dfn>`[role=switch]`{.token .attr-value}</dfn> with `<input type=checkbox>`{
 
 The indeterminate state is supported, but it must be set with JavaScript.
 
+Toggle direction will honor both left-to-right and right-to-left directions (using the `:dir()`{.language-css} pseudo-function).
+Authors using vertical writing modes must add the `.vertical` class until browsers implement logical `translate()`{.language-css} directions (or the `:writing-mode()`{.language-css} pseudo-function).
+
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Toggle switch markup</figcaption>
 

--- a/www/docs/40-aria.md
+++ b/www/docs/40-aria.md
@@ -239,7 +239,6 @@ To get the actual behavior of an accessible feed, you can use [Missing.js &sect;
 Use <dfn>`[role=switch]`{.token .attr-value}</dfn> with `<input type=checkbox>`{.language-html}.
 
 The indeterminate state is supported, but it must be set with JavaScript.
-When used with vertical writing modes, toggle switches require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
 
 <figure>
 <figcaption><sub-title class="allcaps">Example<v-h>: </v-h></sub-title>Toggle switch markup</figcaption>

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -15,20 +15,6 @@ Mechanisms of creating layouts.
 </details>
 
 
-## Writing Modes
-
-Use the <dfn>`.writing-mode:vertical-lr`</dfn> and <dfn>`.writing-mode:vertical-rl`</dfn> classes to enable vertical layouts.
-If used, we recommended placing them on the `<html>`{.language-html} element for best results.
-
-While missing.css prioritizes logical properties, a few components still rely on physical property values (like `transform()`{.language-css}) and require the writing mode classes in order to orient correctly:
-
- - The `.fullbleed` and `.fullscreen` layout utilities,
- - The `[role=switch]` input toggle, and
- - `<progress>`{.language-html} bars (specifically the "indeterminate" animation when `@prefers-reduced-motion()`{.language-css} is not set).
-
-If you aren't using these specific components, missing.css will handle vertical writing-mode natively without the need for extra classes (assuming the author sets `writing-mode` somewhere in their css).
-
-
 ## Centering
 
 <dfn>`.text-align:center`</dfn> center-aligns text.

--- a/www/docs/70-layout.md
+++ b/www/docs/70-layout.md
@@ -125,7 +125,6 @@ Add the <dfn>`.fullbleed`</dfn> class to make an element go outside its containe
 
 The <dfn>`.fullscreen`</dfn> class will size an element to fill the screen.
 
-When used with vertical writing modes, both of these classes require a parent element with either `.writing-mode:vertical-lr` or `.writing-mode:vertical-rl` set.
 These classes will not work on flex children (e.g. children of `.flex-row`, `.flex-column`, or `.flex-switch` containers).
 
 

--- a/www/docs/80-utils.md
+++ b/www/docs/80-utils.md
@@ -300,7 +300,17 @@ Use `<meta name=color-scheme content=light>`{.language-html} instead.
 
 </figure>
 
-    
+
+## Writing Modes
+
+Generally speaking, missing.css will work "out of the box" with all writing modes and directions.
+Until browser support for detecting vertical writing modes has improved,
+  authors should use the <dfn>`.vertical`</dfn> class to correct the animations on [toggle switches][] and indeterminate [progress bars][].
+
+[toggle switches]: /docs/aria/#toggle-switch
+[progress bars]: /docs/forms/#progress-bars
+
+
 ## Reset
     
 ~~Use the <dfn>`.all:initial`</dfn> class to reset all CSS properties on an


### PR DESCRIPTION
 I didn't like the idea of `.writing-mode:<value>` utility classes bc it required too many variants. I was able to fix all directional issues except two uses of `translateX` (toggle switch and indeterminate progress animation). Someday, we'll be able to either use logical `transform` or `:writing-mode()` pseudo, so I just implemented the code using `.vertical` until then.